### PR TITLE
Restrict enable/disable auto-posting to bot owner only

### DIFF
--- a/penguin-overlord/cogs/comics.py
+++ b/penguin-overlord/cogs/comics.py
@@ -403,11 +403,10 @@ class Comics(commands.Cog):
     
     @commands.hybrid_command(name='comic_enable', description='Enable daily comic posting')
     async def comic_enable(self, ctx: commands.Context):
-        """Enable automatic daily comic posting"""
+        """Enable automatic daily comic posting (owner only)"""
         is_owner = ctx.bot.owner_id and ctx.author.id == ctx.bot.owner_id
-        is_manager = ctx.guild and ctx.author.guild_permissions.manage_guild
-        if not (is_owner or is_manager):
-            await ctx.send('❌ You do not have permission to run this command')
+        if not is_owner:
+            await ctx.send('❌ Only the bot owner can enable/disable auto-posting')
             return
         
         self.state['enabled'] = True
@@ -416,11 +415,10 @@ class Comics(commands.Cog):
     
     @commands.hybrid_command(name='comic_disable', description='Disable daily comic posting')
     async def comic_disable(self, ctx: commands.Context):
-        """Disable automatic daily comic posting"""
+        """Disable automatic daily comic posting (owner only)"""
         is_owner = ctx.bot.owner_id and ctx.author.id == ctx.bot.owner_id
-        is_manager = ctx.guild and ctx.author.guild_permissions.manage_guild
-        if not (is_owner or is_manager):
-            await ctx.send('❌ You do not have permission to run this command')
+        if not is_owner:
+            await ctx.send('❌ Only the bot owner can enable/disable auto-posting')
             return
         
         self.state['enabled'] = False

--- a/penguin-overlord/cogs/xkcd_poster.py
+++ b/penguin-overlord/cogs/xkcd_poster.py
@@ -183,10 +183,10 @@ class XKCDPoster(commands.Cog):
 
     @commands.hybrid_command(name='xkcd_enable', description='Enable automatic XKCD posting')
     async def xkcd_enable(self, ctx: commands.Context):
+        """Enable automatic XKCD posting (owner only)"""
         is_owner = ctx.bot.owner_id and ctx.author.id == ctx.bot.owner_id
-        is_manager = ctx.guild and ctx.author.guild_permissions.manage_guild
-        if not (is_owner or is_manager):
-            await ctx.send('❌ You do not have permission to run this command')
+        if not is_owner:
+            await ctx.send('❌ Only the bot owner can enable/disable auto-posting')
             return
         self.state['enabled'] = True
         self._write_state()
@@ -194,10 +194,10 @@ class XKCDPoster(commands.Cog):
 
     @commands.hybrid_command(name='xkcd_disable', description='Disable automatic XKCD posting')
     async def xkcd_disable(self, ctx: commands.Context):
+        """Disable automatic XKCD posting (owner only)"""
         is_owner = ctx.bot.owner_id and ctx.author.id == ctx.bot.owner_id
-        is_manager = ctx.guild and ctx.author.guild_permissions.manage_guild
-        if not (is_owner or is_manager):
-            await ctx.send('❌ You do not have permission to run this command')
+        if not is_owner:
+            await ctx.send('❌ Only the bot owner can enable/disable auto-posting')
             return
         self.state['enabled'] = False
         self._write_state()


### PR DESCRIPTION
- comic_enable/comic_disable: Owner only (not managers)
- xkcd_enable/xkcd_disable: Owner only (not managers)
- Prevents server managers from enabling costly auto-posting
- Set channel and manual posting still available to managers
- Consistent permission model across both cogs