### PR TITLE
fix: Skip description for GovInfo bills to avoid raw HTML content

### DIFF
--- a/penguin-overlord/cogs/us_legislation.py
+++ b/penguin-overlord/cogs/us_legislation.py
@@ -217,9 +217,16 @@ class USLegislation(commands.Cog):
                     description = ""
                     if desc_elem is not None and desc_elem.text:
                         desc = desc_elem.text.strip()
-                        desc = re.sub(r'<[^>]+>', '', desc)  # Strip HTML
-                        desc = unescape(desc)
-                        description = desc[:300] + "..." if len(desc) > 300 else desc
+                        
+                        # Special handling for GovInfo - their descriptions contain full page content
+                        if source_key == 'govinfo_bills':
+                            # Skip description for GovInfo - just use title
+                            description = ""
+                        else:
+                            # Normal RSS feed processing
+                            desc = re.sub(r'<[^>]+>', '', desc)  # Strip HTML tags
+                            desc = unescape(desc)  # Convert HTML entities
+                            description = desc[:300] + "..." if len(desc) > 300 else desc
                     
                     # Mark as posted
                     self.posted_items[source_key].append(link)


### PR DESCRIPTION
GovInfo RSS feeds include the entire page content in the description field, which includes raw HTML, download links, metadata, etc. This clutters the Discord embed. Now GovInfo posts will only show the bill title and link, without the description field.