### PR TITLE
fix: Guard-model prompt contamination and remaining moderation FP classes

### DIFF
--- a/docs/features/AI_MODERATION.md
+++ b/docs/features/AI_MODERATION.md
@@ -55,6 +55,17 @@ Both response styles are understood: Llama Guard's native protocol
 instruction template general models are prompted with. Anything else is
 treated as unparseable and forces `review`.
 
+Guard models are prompted with the **bare message only** — no username
+wrapper, channel context, prior-flag notes, or system prompt. Llama
+Guard's chat template classifies the entire user turn as conversation
+content, so any metadata we add is contamination: measured live, an
+innocent "Nigerian Prince" flagged as doxxing because the channel context
+quoted an earlier SSN test message. The cost is that guard models cannot
+use cross-message context (template models still get the full prompt);
+the payoff halved the false-positive rate on out-of-domain benchmarks.
+Messages with no letters (emoji spam, bare mentions) skip the LLM
+entirely — regex scans still run on everything.
+
 ```env
 MOD_ENABLED=true
 MOD_DRY_RUN=true                      # alert-only; the default

--- a/docs/features/AI_MODERATION.md
+++ b/docs/features/AI_MODERATION.md
@@ -66,6 +66,24 @@ the payoff halved the false-positive rate on out-of-domain benchmarks.
 Messages with no letters (emoji spam, bare mentions) skip the LLM
 entirely — regex scans still run on everything.
 
+### Two-stage second opinion (recommended with a guard model)
+
+```env
+AI_MODERATION_SECOND_MODEL=gemma3:12b       # template model; guard models refused
+# AI_MODERATION_SECOND_CATEGORIES=hate_speech,harassment   (default)
+# AI_MODERATION_SECOND_MIN_CONFIDENCE=0.85                 (default)
+```
+
+Messages the primary model calls safe get a second pass through an
+instruction-following model with the FULL rich prompt (context is safe
+there — template models actually obey "analyze the message, not the
+context"). Only its high-confidence verdicts in the configured categories
+count; everything else is ignored, because its non-hate verdicts (violence
+on game vocabulary, spam on scam jokes) are measured noise. Measured with
+llama-guard3:8b + gemma3:12b: golden-set hate recall 92% → 100% with the
+clean false-positive rate unchanged at 3%; Vicomtech recall 58.7% → 78.7%.
+Cost: one extra model call per scanned message that the primary passed.
+
 ```env
 MOD_ENABLED=true
 MOD_DRY_RUN=true                      # alert-only; the default

--- a/penguin-overlord/ai/features/moderation.py
+++ b/penguin-overlord/ai/features/moderation.py
@@ -212,6 +212,37 @@ def _moderation_uses_guard_model() -> bool:
     from ai import config as ai_config
     return is_guard_model(ai_config.get_feature_config('moderation').model)
 
+
+def _second_opinion_model() -> str:
+    """Optional second-stage model (AI_MODERATION_SECOND_MODEL). Runs the
+    rich template prompt on messages the primary called safe; only its
+    verdicts in SECOND_OPINION_CATEGORIES count. Measured rationale: a
+    bare-prompted guard model is precise but blind to context and coded
+    hate (58.7% Vicomtech recall), while gemma3:12b on the template prompt
+    caught 100% of golden-set hate with zero clean hate FPs — but its
+    non-hate verdicts (violence on game vocab, spam on scam jokes) are
+    noise, so those are ignored."""
+    from ai.config import _env
+    return _env('AI_MODERATION_SECOND_MODEL') or ''
+
+
+def _second_opinion_categories() -> frozenset:
+    # hate_speech AND harassment: gemma labels coded dehumanization
+    # ("your kind always ruins...") harassment at 0.95, while its
+    # rude-banter harassment FPs sit at ~0.75 — the confidence floor
+    # separates them.
+    from ai.config import _env
+    raw = _env('AI_MODERATION_SECOND_CATEGORIES', 'hate_speech,harassment')
+    return frozenset(c.strip().lower() for c in raw.split(',') if c.strip())
+
+
+def _second_opinion_min_confidence() -> float:
+    from ai.config import _env
+    try:
+        return float(_env('AI_MODERATION_SECOND_MIN_CONFIDENCE', '0.85'))
+    except (TypeError, ValueError):
+        return 0.85
+
 _GUARD_UNSAFE_RE = re.compile(r'^unsafe\b[\s,]*((?:S\d{1,2}[\s,]*)*)$',
                               re.IGNORECASE)
 
@@ -344,19 +375,8 @@ class ModerationAnalyzer:
             prompt = safe_content
             system_prompt = None
         else:
-            prompt_parts = [f"Message from '{sanitize_input(username, 64)}'"]
-            if channel_name:
-                prompt_parts.append(f"in #{sanitize_input(channel_name, 64)}")
-            prompt = ' '.join(prompt_parts) + f':\n"""\n{safe_content}\n"""\n'
-
-            if infraction_count:
-                prompt += f"\nNote: this user has {infraction_count} prior flagged message(s) in the last 30 days.\n"
-            if context_messages:
-                joined = '\n'.join(
-                    f"- {sanitize_input(m, 200)}" for m in context_messages[-5:]
-                )
-                prompt += f"\nRecent channel context (oldest first):\n{joined}\n"
-            prompt += "\nAnalyze the message (not the context) and respond in the required format."
+            prompt = self._template_prompt(safe_content, username, channel_name,
+                                           context_messages, infraction_count)
             system_prompt = MODERATION_SYSTEM_PROMPT
 
         raw = None
@@ -387,7 +407,72 @@ class ModerationAnalyzer:
                 result.category = 'hate_speech'
                 result.reason = 'blocklisted term detected (regex)'
             result.confidence = max(result.confidence, 0.95)
+
+        if result.is_safe:
+            second = await self._second_opinion(
+                safe_content, username, channel_name, context_messages,
+                infraction_count,
+            )
+            if second is not None:
+                return second
         return result
+
+    @staticmethod
+    def _template_prompt(safe_content: str, username: str, channel_name: str,
+                         context_messages: list, infraction_count: int) -> str:
+        prompt_parts = [f"Message from '{sanitize_input(username, 64)}'"]
+        if channel_name:
+            prompt_parts.append(f"in #{sanitize_input(channel_name, 64)}")
+        prompt = ' '.join(prompt_parts) + f':\n"""\n{safe_content}\n"""\n'
+
+        if infraction_count:
+            prompt += f"\nNote: this user has {infraction_count} prior flagged message(s) in the last 30 days.\n"
+        if context_messages:
+            joined = '\n'.join(
+                f"- {sanitize_input(m, 200)}" for m in context_messages[-5:]
+            )
+            prompt += f"\nRecent channel context (oldest first):\n{joined}\n"
+        prompt += "\nAnalyze the message (not the context) and respond in the required format."
+        return prompt
+
+    async def _second_opinion(self, safe_content: str, username: str,
+                              channel_name: str, context_messages: list,
+                              infraction_count: int):
+        """Optional second-stage pass on primary-safe messages: a template
+        model with full context, whose verdict counts only for the
+        configured categories (default hate_speech). Returns a
+        ModerationResult to use instead, or None to keep the primary."""
+        model = _second_opinion_model()
+        if not model:
+            return None
+        if is_guard_model(model):
+            # A guard model can't consume the template prompt (that's the
+            # contamination bug this design avoids) — misconfiguration.
+            logger.error('AI_MODERATION_SECOND_MODEL must be a template '
+                         'model, not a guard model; ignoring %s', model)
+            return None
+
+        prompt = self._template_prompt(safe_content, username, channel_name,
+                                       context_messages, infraction_count)
+        try:
+            raw = await self._manager.generate(
+                feature='moderation', prompt=prompt,
+                system_prompt=MODERATION_SYSTEM_PROMPT,
+                raw=True, model=model,
+            )
+        except Exception as e:
+            logger.error(f"Second-opinion generate failed: {type(e).__name__}")
+            return None
+        if raw is None:
+            return None
+
+        second = parse_moderation_response(raw)
+        if (second.is_safe
+                or second.category not in _second_opinion_categories()
+                or second.confidence < _second_opinion_min_confidence()):
+            return None
+        second.reason = f"second opinion ({model}): {second.reason}"
+        return second
 
 
 # ---------------------------------------------------------------------------

--- a/penguin-overlord/ai/features/moderation.py
+++ b/penguin-overlord/ai/features/moderation.py
@@ -125,11 +125,38 @@ PII_PATTERNS = {
 }
 
 
+# Well-known public infrastructure IPs everyone pastes in tech chat
+# (resolvers, quad-style anycast). Not anyone's personal information.
+WELL_KNOWN_IPS = frozenset({
+    '8.8.8.8', '8.8.4.4',            # Google DNS
+    '1.1.1.1', '1.0.0.1',            # Cloudflare DNS
+    '9.9.9.9', '149.112.112.112',    # Quad9
+    '208.67.222.222', '208.67.220.220',  # OpenDNS
+    '4.2.2.2', '4.2.2.1',            # Level3
+})
+
+# Discord markup whose payload is an ID, not PII: user/role mentions,
+# channel links, custom emoji, timestamps. A pasted <@205412…> mention
+# used to flag as pii_exposure.
+_DISCORD_SYNTAX_RE = re.compile(
+    r'<(?:@[!&]?|#|a?:\w+:|t:)\d+(?::[a-zA-Z])?>'
+)
+
+
+def strip_discord_syntax(text: str) -> str:
+    """Remove Discord mention/emoji/channel/timestamp markup before regex
+    scans — their embedded snowflake IDs are not personal information."""
+    return _DISCORD_SYNTAX_RE.sub(' ', text)
+
+
 def _is_public_ip(candidate: str) -> bool:
-    """Only globally-routable IPs count as PII. Tech servers paste LAN and
-    loopback addresses (192.168.x, 10.x, 127.0.0.1) constantly — flagging
-    those buried the mod channel in pii_exposure false positives. Invalid
-    dotted quads (an octet > 255) are rejected too."""
+    """Only globally-routable, non-well-known IPs count as PII. Tech servers
+    paste LAN and loopback addresses (192.168.x, 10.x, 127.0.0.1) and public
+    resolvers (8.8.8.8, 1.1.1.1) constantly — flagging those buried the mod
+    channel in pii_exposure false positives. Invalid dotted quads (an octet
+    > 255) are rejected too."""
+    if candidate in WELL_KNOWN_IPS:
+        return False
     try:
         return ipaddress.ip_address(candidate).is_global
     except ValueError:
@@ -138,6 +165,7 @@ def _is_public_ip(candidate: str) -> bool:
 
 def pre_scan_pii(text: str) -> list:
     """Fast regex PII scan; returns the PII types found."""
+    text = strip_discord_syntax(text)
     found = []
     for name, pattern in PII_PATTERNS.items():
         if name == 'ip_address':
@@ -154,6 +182,10 @@ def pre_scan_pii(text: str) -> list:
 # sensible mapping stay 'unknown', which forces human review.
 GUARD_CATEGORY_MAP = {
     'S1': 'violence',        # violent crimes
+    'S2': 'social_engineering',  # non-violent crimes: fraud/scams — labeled
+                                 # so operators can mute via
+                                 # MOD_IGNORED_CATEGORIES in scam-joke-heavy
+                                 # security communities
     'S3': 'sexual_content',  # sex-related crimes
     'S4': 'sexual_content',  # child sexual exploitation
     'S5': 'harassment',      # defamation
@@ -168,6 +200,17 @@ GUARD_CATEGORY_MAP = {
 # Guard models emit a verdict with no confidence score; treat their
 # fixed-taxonomy verdicts as high- but not denylist-level confidence.
 GUARD_VERDICT_CONFIDENCE = 0.85
+
+
+def is_guard_model(model: str) -> bool:
+    """Guard-style classifiers (llama-guard*, *guard*) answer in a fixed
+    protocol and must be prompted with bare content only."""
+    return 'guard' in (model or '').lower()
+
+
+def _moderation_uses_guard_model() -> bool:
+    from ai import config as ai_config
+    return is_guard_model(ai_config.get_feature_config('moderation').model)
 
 _GUARD_UNSAFE_RE = re.compile(r'^unsafe\b[\s,]*((?:S\d{1,2}[\s,]*)*)$',
                               re.IGNORECASE)
@@ -288,25 +331,39 @@ class ModerationAnalyzer:
         denylist_hits = find_blocked_terms(message_content)
 
         safe_content = sanitize_input(message_content, max_length=1500)
-        prompt_parts = [f"Message from '{sanitize_input(username, 64)}'"]
-        if channel_name:
-            prompt_parts.append(f"in #{sanitize_input(channel_name, 64)}")
-        prompt = ' '.join(prompt_parts) + f':\n"""\n{safe_content}\n"""\n'
 
-        if infraction_count:
-            prompt += f"\nNote: this user has {infraction_count} prior flagged message(s) in the last 30 days.\n"
-        if context_messages:
-            joined = '\n'.join(
-                f"- {sanitize_input(m, 200)}" for m in context_messages[-5:]
-            )
-            prompt += f"\nRecent channel context (oldest first):\n{joined}\n"
-        prompt += "\nAnalyze the message (not the context) and respond in the required format."
+        if _moderation_uses_guard_model():
+            # Llama Guard's chat template wraps whatever we send in its own
+            # classification task and assesses the ENTIRE user turn as the
+            # conversation. Any metadata we add — username wrapper, channel
+            # context, prior-flag notes, our instruction system prompt — is
+            # classified as content, and context quoting a prior SSN or slur
+            # poisons the verdict for an innocent message (measured live:
+            # "Nigerian Prince" -> unsafe S7 with contaminated context, safe
+            # bare). Guard models get the bare message and nothing else.
+            prompt = safe_content
+            system_prompt = None
+        else:
+            prompt_parts = [f"Message from '{sanitize_input(username, 64)}'"]
+            if channel_name:
+                prompt_parts.append(f"in #{sanitize_input(channel_name, 64)}")
+            prompt = ' '.join(prompt_parts) + f':\n"""\n{safe_content}\n"""\n'
+
+            if infraction_count:
+                prompt += f"\nNote: this user has {infraction_count} prior flagged message(s) in the last 30 days.\n"
+            if context_messages:
+                joined = '\n'.join(
+                    f"- {sanitize_input(m, 200)}" for m in context_messages[-5:]
+                )
+                prompt += f"\nRecent channel context (oldest first):\n{joined}\n"
+            prompt += "\nAnalyze the message (not the context) and respond in the required format."
+            system_prompt = MODERATION_SYSTEM_PROMPT
 
         raw = None
         try:
             raw = await self._manager.generate(
                 feature='moderation', prompt=prompt,
-                system_prompt=MODERATION_SYSTEM_PROMPT,
+                system_prompt=system_prompt,
                 raw=True,
             )
         except Exception as e:

--- a/penguin-overlord/ai/manager.py
+++ b/penguin-overlord/ai/manager.py
@@ -78,16 +78,20 @@ class AIManager:
 
     async def generate(self, feature: str, prompt: str, system_prompt: str = None,
                        temperature: float = None, max_tokens: int = None,
-                       timeout: float = None, raw: bool = False):
+                       timeout: float = None, raw: bool = False,
+                       model: str = None):
         """Generate text for *feature*. Returns cleaned text or None.
 
         raw=True skips output cleanup/dedup (used by structured analyzers
         that parse the response themselves) — the deny-list still applies
-        to anything a caller might post.
+        to anything a caller might post. model= overrides the feature's
+        configured model for this one call (second-opinion passes).
         """
         cfg = ai_config.get_feature_config(feature)
         if not cfg.enabled:
             return None
+        if model:
+            cfg.model = model
 
         temperature = cfg.temperature if temperature is None else temperature
         max_tokens = cfg.max_tokens if max_tokens is None else max_tokens

--- a/penguin-overlord/ai/moderation_golden.json
+++ b/penguin-overlord/ai/moderation_golden.json
@@ -64,6 +64,19 @@
     {"text": "chat is being extra spicy today lol", "note": "meta banter"},
     {"text": "I hate this boss fight so much", "note": "'hate' the word, no target"},
     {"text": "kill the demon before it heals, aim for the head", "note": "game-violence vocabulary"},
-    {"text": "my build is trash, gonna respec tonight", "note": "self-deprecation"}
+    {"text": "my build is trash, gonna respec tonight", "note": "self-deprecation"},
+
+    {"text": "Nigerian Prince", "note": "real FP: scam trope reference, flagged S7 via context contamination"},
+    {"text": "classic nigerian prince email, he wants my routing number lol", "note": "scam joke in full sentence"},
+    {"text": "🤣🤣🤣🤣🤣🤣", "note": "real FP: emoji-only message flagged doxxing"},
+    {"text": "<@205412430510030848>", "note": "real FP: bare user mention flagged pii_exposure"},
+    {"text": "ping <@!99999999999999999> and <#123456789012345678> about it", "note": "mention + channel link markup"},
+    {"text": "my favorite is <a:blobhype:112233445566778899>", "note": "animated custom emoji markup"},
+    {"text": "127.0.0.1", "note": "real FP: bare loopback"},
+    {"text": "could we whitelist ips like 8.8.8.8 so public resolvers don't get flagged but personal IPs still do", "note": "real FP: feature request naming a public resolver"},
+    {"text": "set your dns to 1.1.1.1 and 9.9.9.9, way faster than the ISP default", "note": "well-known resolver advice"},
+    {"text": "the mod bot is in training mode, we're feeding it test data for a few days before tuning it on the hate speech datasets I archived", "note": "real FP class: meta-discussion of moderation training data"},
+    {"text": "yeah it's a little too sensitive right now, still a WIP, checking the logs", "note": "real FP: meta-discussion of the bot"},
+    {"text": "It failed the Nigeria test", "note": "real FP: country name once tripped repeat-collapse"}
   ]
 }

--- a/penguin-overlord/cogs/ai_moderation.py
+++ b/penguin-overlord/cogs/ai_moderation.py
@@ -226,7 +226,12 @@ class AIModeration(commands.Cog):
         denylist_hits = find_blocked_terms(content)
 
         # Short messages skip the LLM unless a regex already found something
-        run_llm = len(content) >= self.min_message_length or bool(pii) or bool(denylist_hits)
+        # A message with no letters (emoji spam, a bare mention, kaomoji)
+        # has nothing for a language model to classify — live testing showed
+        # such messages picking up spurious verdicts. Regex scans still ran.
+        has_letters = any(ch.isalpha() for ch in content)
+        run_llm = ((len(content) >= self.min_message_length and has_letters)
+                   or bool(pii) or bool(denylist_hits))
 
         # Per-user cooldown applies to LLM scans only; regex hits always proceed
         now = time.monotonic()

--- a/scripts/eval-moderation/eval_guard.py
+++ b/scripts/eval-moderation/eval_guard.py
@@ -92,9 +92,10 @@ async def main():
 
     class EvalManager:
         async def generate(self, feature, prompt, system_prompt=None,
-                           raw=False, **kw):
+                           raw=False, model=None, **kw):
             return await provider.generate(
-                model=args.model, prompt=prompt, system_prompt=system_prompt,
+                model=model or args.model, prompt=prompt,
+                system_prompt=system_prompt,
                 temperature=0.0, max_tokens=256, timeout=90,
             )
 

--- a/scripts/eval-moderation/eval_guard.py
+++ b/scripts/eval-moderation/eval_guard.py
@@ -4,9 +4,9 @@
 
 """Benchmark a moderation model against the Vicomtech hate-speech dataset.
 
-Replicates the bot's exact request shape (chat endpoint, system prompt,
-wrapped user prompt) and its real response parser, so the numbers reflect
-what the AIModeration cog would actually decide.
+Routes every sample through the bot's REAL ModerationAnalyzer (guard-bare
+vs template-wrapped prompt shape, parser, deny-list merge), so the numbers
+reflect what the AIModeration cog would actually decide.
 
 Usage:
     git clone https://github.com/Vicomtech/hate-speech-dataset.git /tmp/hsd
@@ -14,8 +14,11 @@ Usage:
         --dataset /tmp/hsd --host http://192.168.1.50:11434 \
         --model llama-guard3:8b --n 75
 
-Baseline (2026-08-28, stock llama-guard3:8b, n=75/class, seed 42):
-    hate recall 70.7% — noHate false-positive rate 21.3%
+Baselines (stock llama-guard3:8b, n=75/class, seed 42):
+    2026-08-28 contaminated wrapper prompt: recall 70.7%, FP rate 21.3%
+    2026-08-29 guard-native bare prompt:    recall 58.7%, FP rate 10.7%
+(the deny-list still catches slur-bearing hate at 100% regardless; the
+recall gap is slur-free coded hate — the fine-tune's target)
 See docs/features/MODERATION_FINETUNE_PLAN.md for the fine-tune this
 benchmark gates.
 """
@@ -30,13 +33,10 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 sys.path.insert(0, str(REPO_ROOT / 'penguin-overlord'))
 
-import ollama  # noqa: E402
+import os  # noqa: E402
 
-from ai.features.moderation import (  # noqa: E402
-    MODERATION_SYSTEM_PROMPT,
-    parse_moderation_response,
-)
-from ai.guardrails import sanitize_input  # noqa: E402
+from ai.features.moderation import ModerationAnalyzer  # noqa: E402
+from ai.providers import OllamaProvider  # noqa: E402
 
 
 def load_samples(dataset: Path, n_per_class: int, seed: int):
@@ -54,24 +54,12 @@ def load_samples(dataset: Path, n_per_class: int, seed: int):
             rng.sample(by_label['noHate'], n_per_class))
 
 
-def build_prompt(content: str) -> str:
-    safe = sanitize_input(content, max_length=1500)
-    return (f"Message from 'testuser' in #general:\n\"\"\"\n{safe}\n\"\"\"\n"
-            "\nAnalyze the message (not the context) and respond in the required format.")
-
-
-async def classify(client, sem, model, text):
+async def classify(analyzer, sem, text):
+    """Route through the REAL analyzer so prompt shape (guard-bare vs
+    template-wrapped), parser, and deny-list merge all match the bot."""
     async with sem:
         try:
-            resp = await asyncio.wait_for(client.chat(
-                model=model,
-                messages=[
-                    {'role': 'system', 'content': MODERATION_SYSTEM_PROMPT},
-                    {'role': 'user', 'content': build_prompt(text)},
-                ],
-                options={'temperature': 0.7, 'num_predict': 256},
-            ), timeout=90)
-            return parse_moderation_response(resp.message.content.strip())
+            return await analyzer.analyze(text, 'evaluser')
         except Exception as e:
             print('ERR', type(e).__name__, e, file=sys.stderr)
             return None
@@ -97,14 +85,26 @@ async def main():
     ap.add_argument('--concurrency', type=int, default=2)
     args = ap.parse_args()
 
+    os.environ['AI_MODERATION_MODEL'] = args.model
     hate, no_hate = load_samples(args.dataset, args.n, args.seed)
-    client = ollama.AsyncClient(host=args.host)
+
+    provider = OllamaProvider(args.host)
+
+    class EvalManager:
+        async def generate(self, feature, prompt, system_prompt=None,
+                           raw=False, **kw):
+            return await provider.generate(
+                model=args.model, prompt=prompt, system_prompt=system_prompt,
+                temperature=0.0, max_tokens=256, timeout=90,
+            )
+
+    analyzer = ModerationAnalyzer(EvalManager())
     sem = asyncio.Semaphore(args.concurrency)
 
     hate_results = await asyncio.gather(
-        *(classify(client, sem, args.model, t) for t in hate))
+        *(classify(analyzer, sem, t) for t in hate))
     nohate_results = await asyncio.gather(
-        *(classify(client, sem, args.model, t) for t in no_hate))
+        *(classify(analyzer, sem, t) for t in no_hate))
 
     h_done, h_unsafe, h_cats = stats(hate_results)
     n_done, n_unsafe, n_cats = stats(nohate_results)

--- a/tests/unit/test_ai_moderation_cog.py
+++ b/tests/unit/test_ai_moderation_cog.py
@@ -111,6 +111,28 @@ async def test_short_message_skips_llm_but_regex_pii_still_alerts(cog):
     assert 'ssn' in detections[0].pii_detected
 
 
+async def test_letterless_messages_skip_llm(cog):
+    # Live FP: '🤣🤣🤣🤣🤣🤣' picked up a spurious model verdict. No letters,
+    # nothing to classify — the LLM must not run (regex scans still do).
+    cog.analyzer = RecordingAnalyzer(
+        ModerationResult(True, 'safe', 0.9, 'x', 'none'))
+    cog.db = FakeDB()
+    detections = []
+
+    async def record(message, content, result, decision):
+        detections.append(result)
+    cog._handle_detection = record
+
+    for content in ('🤣🤣🤣🤣🤣🤣', '!!!???!!!', '<@205412430510030848>'):
+        await cog._scan_message(make_message(content), content)
+    assert cog.analyzer.calls == [] and detections == []
+
+    # An SSN with no letters still alerts: the regex hit forces the scan
+    ssn = '123-45-6789'
+    await cog._scan_message(make_message(ssn), ssn)
+    assert len(detections) == 1 and detections[0].category == 'pii_exposure'
+
+
 async def test_user_cooldown_skips_llm(cog):
     cog.analyzer = RecordingAnalyzer(
         ModerationResult(True, 'safe', 0.9, 'x', 'none'))

--- a/tests/unit/test_moderation.py
+++ b/tests/unit/test_moderation.py
@@ -287,6 +287,99 @@ class StubManager:
         return self._response
 
 
+# -- second-opinion stage ----------------------------------------------------
+
+class TwoStageManager:
+    """First call answers as the primary model, second as the second model."""
+
+    def __init__(self, primary, second):
+        self._responses = [primary, second]
+        self.calls = []
+
+    async def generate(self, **kwargs):
+        self.calls.append(kwargs)
+        return self._responses[min(len(self.calls) - 1, 1)]
+
+
+SECOND_HATE = ("SAFE: false\nCATEGORY: hate_speech\nCONFIDENCE: 0.9\n"
+               "REASON: coded dehumanization\nACTION: review\nPII: none")
+SECOND_SPAM = ("SAFE: false\nCATEGORY: spam\nCONFIDENCE: 0.95\n"
+               "REASON: looks like an ad\nACTION: delete\nPII: none")
+
+
+async def test_second_opinion_catches_hate_primary_missed(monkeypatch):
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma3:12b')
+    manager = TwoStageManager('safe', SECOND_HATE)
+    analyzer = ModerationAnalyzer(manager)
+    r = await analyzer.analyze('your kind always ruins every community', 'x',
+                               context_messages=['earlier line'])
+    assert not r.is_safe and r.category == 'hate_speech'
+    assert 'second opinion (gemma3:12b)' in r.reason
+    assert len(manager.calls) == 2
+    # Second pass uses the rich template prompt with context
+    assert 'Recent channel context' in manager.calls[1]['prompt']
+    assert manager.calls[1]['model'] == 'gemma3:12b'
+
+
+async def test_second_opinion_non_hate_verdicts_ignored(monkeypatch):
+    # gemma's non-hate verdicts (spam on scam jokes, violence on game
+    # vocab) are measured noise — only configured categories count.
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma3:12b')
+    analyzer = ModerationAnalyzer(TwoStageManager('safe', SECOND_SPAM))
+    r = await analyzer.analyze('classic nigerian prince email lol', 'x')
+    assert r.is_safe
+
+
+async def test_second_opinion_high_conf_harassment_counts(monkeypatch):
+    # Measured: gemma labels coded dehumanization harassment at 0.95
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma3:12b')
+    high = SECOND_HATE.replace('hate_speech', 'harassment').replace('0.9', '0.95')
+    analyzer = ModerationAnalyzer(TwoStageManager('safe', high))
+    r = await analyzer.analyze('your kind always ruins everything', 'x')
+    assert not r.is_safe and r.category == 'harassment'
+
+
+async def test_second_opinion_low_conf_harassment_ignored(monkeypatch):
+    # ...while its rude-banter harassment FPs sit around 0.75 — under floor
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma3:12b')
+    low = SECOND_HATE.replace('hate_speech', 'harassment').replace('0.9', '0.75')
+    analyzer = ModerationAnalyzer(TwoStageManager('safe', low))
+    r = await analyzer.analyze('this take is absolute garbage', 'x')
+    assert r.is_safe
+
+
+async def test_second_opinion_skipped_when_primary_flags(monkeypatch):
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma3:12b')
+    manager = TwoStageManager('unsafe\nS10', SECOND_HATE)
+    analyzer = ModerationAnalyzer(manager)
+    r = await analyzer.analyze('some flagged message', 'x')
+    assert not r.is_safe and r.category == 'hate_speech'
+    assert len(manager.calls) == 1
+
+
+async def test_second_opinion_off_by_default(monkeypatch):
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.delenv('AI_MODERATION_SECOND_MODEL', raising=False)
+    manager = TwoStageManager('safe', SECOND_HATE)
+    analyzer = ModerationAnalyzer(manager)
+    r = await analyzer.analyze('anything at all really', 'x')
+    assert r.is_safe and len(manager.calls) == 1
+
+
+async def test_second_opinion_guard_model_refused(monkeypatch):
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'llama-guard3:8b')
+    manager = TwoStageManager('safe', 'unsafe\nS10')
+    analyzer = ModerationAnalyzer(manager)
+    r = await analyzer.analyze('anything at all really', 'x')
+    assert r.is_safe and len(manager.calls) == 1
+
+
 # -- guard-model prompt isolation --------------------------------------------
 
 async def test_guard_model_gets_bare_content_only(monkeypatch):

--- a/tests/unit/test_moderation.py
+++ b/tests/unit/test_moderation.py
@@ -101,10 +101,17 @@ def test_parse_guard_unsafe_multiple_codes_first_mapped_wins():
 
 
 def test_parse_guard_unsafe_unmapped_code_forces_review():
-    r = parse_moderation_response("unsafe\nS2")
+    r = parse_moderation_response("unsafe\nS8")
     assert not r.is_safe
     assert r.category == 'unknown'
     assert r.suggested_action == 'review'
+
+
+def test_parse_guard_s2_maps_social_engineering():
+    # S2 (fraud/scams) gets a real label so mods can read it and operators
+    # can mute the category if scam jokes make it noisy.
+    r = parse_moderation_response("unsafe\nS2")
+    assert r.category == 'social_engineering'
 
 
 def test_parse_guard_unsafe_no_code():
@@ -169,7 +176,32 @@ def test_pii_private_ips_are_not_pii():
     # tech server and are not doxxing material.
     for text in ("ssh into 192.168.1.50", "server at 10.0.0.5", "loopback 127.0.0.1"):
         assert pre_scan_pii(text) == [], text
-    assert 'ip_address' in pre_scan_pii("attacker came from 8.8.8.8")
+    assert 'ip_address' in pre_scan_pii("attacker came from 84.12.34.56")
+
+
+def test_pii_well_known_ips_are_not_pii():
+    # Live-deployment regression: a user asking to whitelist 8.8.8.8 got
+    # flagged for pasting 8.8.8.8. Public resolvers are not doxxing.
+    for text in ("set dns to 8.8.8.8", "cloudflare is 1.1.1.1", "quad9 9.9.9.9"):
+        assert pre_scan_pii(text) == [], text
+
+
+def test_pii_discord_markup_is_stripped():
+    # Live-deployment regression: a pasted <@mention> flagged pii_exposure —
+    # the embedded snowflake matched digit-run heuristics.
+    from ai.features.moderation import strip_discord_syntax
+    for text in (
+        "<@205412430510030848>",
+        "ping <@!99999999999999999> about it",
+        "role ping <@&123456789012345678>",
+        "see <#123456789012345678>",
+        "love this emote <a:blobhype:112233445566778899>",
+        "meeting at <t:1724900000:R>",
+    ):
+        assert pre_scan_pii(text) == [], text
+    # Stripping never eats surrounding content
+    assert strip_discord_syntax("call me at 555-867-5309 <@12345678901234567>").strip().startswith("call me")
+    assert 'phone' in pre_scan_pii("call me at 555-867-5309 <@12345678901234567>")
 
 
 def test_pii_digit_runs_are_not_phone_numbers():
@@ -248,9 +280,44 @@ def test_auto_action_needs_flag_and_confidence():
 class StubManager:
     def __init__(self, response):
         self._response = response
+        self.calls = []
 
     async def generate(self, **kwargs):
+        self.calls.append(kwargs)
         return self._response
+
+
+# -- guard-model prompt isolation --------------------------------------------
+
+async def test_guard_model_gets_bare_content_only(monkeypatch):
+    # Llama Guard's template classifies the ENTIRE user turn as conversation
+    # content: username wrappers, channel context, and prior-flag notes are
+    # contamination. Measured live: "Nigerian Prince" -> unsafe S7 when the
+    # context quoted an SSN test message, safe when sent bare.
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    manager = StubManager('safe')
+    analyzer = ModerationAnalyzer(manager)
+    await analyzer.analyze(
+        'Nigerian Prince', 'someone', channel_name='general',
+        context_messages=['someone: my ssn is 123-45-6789'], infraction_count=2,
+    )
+    call = manager.calls[0]
+    assert call['prompt'] == 'Nigerian Prince'
+    assert call['system_prompt'] is None
+
+
+async def test_template_model_keeps_rich_prompt(monkeypatch):
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama3.1:8b')
+    manager = StubManager('SAFE: true\nCATEGORY: safe\nCONFIDENCE: 0.9\nREASON: x\nACTION: none\nPII: none')
+    analyzer = ModerationAnalyzer(manager)
+    await analyzer.analyze(
+        'Nigerian Prince', 'someone', channel_name='general',
+        context_messages=['earlier chat line'], infraction_count=2,
+    )
+    call = manager.calls[0]
+    assert 'Recent channel context' in call['prompt']
+    assert 'prior flagged message' in call['prompt']
+    assert call['system_prompt'] is not None
 
 
 async def test_analyzer_denylist_works_without_model():

--- a/tests/unit/test_moderation_live.py
+++ b/tests/unit/test_moderation_live.py
@@ -45,10 +45,11 @@ class LiveOllamaManager:
         self._provider = OllamaProvider(host)
         self._lock = asyncio.Semaphore(2)
 
-    async def generate(self, feature, prompt, system_prompt=None, raw=False, **kwargs):
+    async def generate(self, feature, prompt, system_prompt=None, raw=False,
+                       model=None, **kwargs):
         async with self._lock:
             return await self._provider.generate(
-                model=MODEL, prompt=prompt, system_prompt=system_prompt,
+                model=model or MODEL, prompt=prompt, system_prompt=system_prompt,
                 temperature=0.0, max_tokens=256, timeout=60,
             )
 


### PR DESCRIPTION
## The bug

Every real false positive the mods labeled traced to one root cause: llama-guard's Ollama chat template classifies the **entire user turn** as conversation content, and renders the system prompt as an Agent turn inside the conversation. Our username wrapper, channel context, prior-flag notes, and 400-word instruction system prompt were all being *classified as content*. With the channel context quoting SSN test messages, an innocent "Nigerian Prince" deterministically flagged as `unsafe S7` (doxxing); bare, it's `safe`.

## Fixes

- **Guard models get the bare message only** — no wrapper, context, prior-flags, or system prompt. Template models keep the rich prompt.
- **Discord markup stripped before PII scan** — `<@mention>`, custom emoji, channel links, timestamps no longer flag their snowflakes.
- **Well-known resolver IPs allowlisted** (8.8.8.8, 1.1.1.1, 9.9.9.9…) — requested in-channel by a user whose whitelist suggestion got flagged for containing 8.8.8.8.
- **Letterless messages skip the LLM** (emoji spam, bare mentions); regex still runs.
- **Guard S2 → social_engineering** so scam-joke alerts carry a readable, mutable label.
- **Golden corpus +12 cases** from real moderator ❌ labels; eval script now routes through the real analyzer.

## Measured

- 7 of 8 real moderator-labeled FPs eliminated even under maximum context poisoning (the holdout mentions white-supremacist datasets and flags S10 even bare — fine-tune territory).
- Vicomtech (n=75/class, seed 42): FP rate **21.3% → 10.7%**; recall 70.7% → 58.7% (contamination was inflating both; slur-bearing hate remains 100% via deny-list).
- Golden set: 95% accuracy, 3% clean FP.
- 178 unit tests pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)