### PR TITLE
fix: think=false on Ollama chat calls (gemma4 thinking-model support)

### DIFF
--- a/penguin-overlord/ai/providers.py
+++ b/penguin-overlord/ai/providers.py
@@ -94,6 +94,13 @@ class OllamaProvider:
                 self._client.chat(
                     model=model,
                     messages=messages,
+                    # Thinking models (gemma4, qwen3, ...) otherwise burn the
+                    # whole num_predict budget on reasoning and return empty
+                    # content. Every feature here wants a direct answer;
+                    # non-thinking models ignore the flag (verified on
+                    # Ollama 0.33). The thinking-field fallback below stays
+                    # for servers that don't honor it.
+                    think=False,
                     options={
                         'temperature': temperature,
                         'num_predict': max_tokens,

--- a/tests/unit/test_ai_providers.py
+++ b/tests/unit/test_ai_providers.py
@@ -18,8 +18,9 @@ class FakeOllamaClient:
         self.delay = delay
         self.calls = []
 
-    async def chat(self, model, messages, options):
-        self.calls.append({'model': model, 'messages': messages, 'options': options})
+    async def chat(self, model, messages, options, think=None):
+        self.calls.append({'model': model, 'messages': messages,
+                           'options': options, 'think': think})
         if self.delay:
             await asyncio.sleep(self.delay)
         if self.exc:
@@ -51,6 +52,8 @@ async def test_generate_returns_content():
     assert out == 'hello world'
     roles = [m['role'] for m in client.calls[0]['messages']]
     assert roles == ['system', 'user']
+    # Thinking models must not burn the token budget on reasoning
+    assert client.calls[0]['think'] is False
 
 
 async def test_generate_no_system_prompt_sends_only_user():


### PR DESCRIPTION
gemma4:12b thinks by default and returns empty content after burning the whole token budget on reasoning — the provider then degrades features as if the model were down. `think=false` makes it answer directly; verified harmless on non-thinking models (llama-guard3, gemma3) against Ollama 0.33.2.

Benchmarks with the fix (temp 0): gemma4 solo golden **100%/100%/0% FP**; guard+gemma4 ensemble golden 98%/100%/3% and Vicomtech 77.3%/18.7% — on par with the gemma3 ensemble, with a stronger solo profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)