### PR TITLE
feat: Expand watchlist to curated ADL set; humor-aware adjudication

### DIFF
--- a/docs/features/AI_MODERATION.md
+++ b/docs/features/AI_MODERATION.md
@@ -158,8 +158,13 @@ strict behavior applies everywhere.
 
 ### Dog-whistle watchlist (ADL Hate on Display)
 
-Coded hate terms with common benign readings (`88`, the 14 words, echo
-parentheses, 13/52, ZOG, "great replacement", …) live on a **watchlist**,
+Coded hate terms with common benign readings live on a **watchlist** —
+~45 patterns curated from the full ADL Hate on Display database: numeric
+codes (88, 14/88, 13/52…), acronyms (ZOG, GTKRWN, the Klan call-signs),
+slogans (sieg heil, white genocide, blood and soil…), and antisemitic
+meme phrases (six gorillion, goyim know…). Deliberately excluded: purely
+visual symbols and terms that collide with this community's normal talk
+(ORION spacecraft, "storm front" weather, bare numbers). The watchlist is
 separate from the hard deny-list — in a ham-radio community, "73 and 88,
 closing the net" is a signoff, not a Heil Hitler. A watchlist hit never
 auto-alerts and never auto-passes: it forces LLM analysis plus a context
@@ -171,7 +176,10 @@ adjudication with a three-way distinction:
 - **benign** — signoffs, years, prices, piano keys → no alert
 - **mention** — *discussing or warning about* the code (mod talk,
   education, news) → no alert; use–mention distinction is explicit in
-  both the adjudication and the main system prompt
+  both the adjudication and the main system prompt. **Humor is handled**:
+  jokes mocking extremists pass as benign/mention; "irony" that still
+  functions as the signal flags as hateful; genuinely ambiguous jokes go
+  to review
 - **uncertain** / model down → a low-confidence `evasion` review alert
   (fail open, softer label)
 

--- a/penguin-overlord/ai/features/moderation.py
+++ b/penguin-overlord/ai/features/moderation.py
@@ -522,6 +522,11 @@ class ModerationAnalyzer:
             "prices, quantities, piano keys, frequencies\n"
             "- mention: DISCUSSING, quoting, or warning about the code "
             "itself (educational or moderation talk about dog whistles)\n"
+            "Humor matters: jokes MOCKING nazis or extremists, and absurdist "
+            "meme humor between friends, are benign or mention. 'Irony' that "
+            "still functions as the signal — asserting the coded claim, or "
+            "aimed at a group or person — is hateful. When a joke is "
+            "genuinely ambiguous, answer uncertain.\n"
             "Respond in EXACTLY this format:\n"
             "VERDICT: hateful/benign/mention/uncertain\n"
             "REASON: <one short sentence>",

--- a/penguin-overlord/ai/guardrails.py
+++ b/penguin-overlord/ai/guardrails.py
@@ -129,23 +129,66 @@ def _load_operator_blocklist() -> tuple:
 # analysis plus a context adjudication distinguishing hateful use from
 # benign use from MENTION (discussing or warning about the code itself).
 # Unambiguous coded phrases belong in the deny-list, not here.
+# Text-expressible entries curated from the ADL Hate on Display database
+# (https://www.adl.org/resources/hate-symbols/search). Deliberately
+# excluded: purely visual symbols, and bare numbers/acronyms too common in
+# ordinary chat to survive even adjudication volume (12, 13, 14, 18, 23,
+# 100%, H8, WP, ORION — a spacecraft in this community, "moon man" —
+# space talk, "storm front" — weather talk; 'stormfront' one word kept).
 _DOGWHISTLE_PATTERNS = (
+    # numeric codes
     ('88', r'\b88\b'),
-    ('14 words', r'\b14\s*words\b'),
-    ('14/88', r'\b14\s*[/-]\s*88\b'),
+    ('14 words', r'\b(?:14|fourteen)\s*words\b'),
+    ('14/88', r'\b(?:14\s*[/-]\s*88|8814)\b'),
+    ('14/23', r'\b14\s*/\s*23\b'),
+    ('23/16', r'\b(?:23\s*/\s*16|16\s*/\s*23)\b'),
     ('109 countries', r'\b109\s+countries\b'),
-    ('13/52', r'\b13\s*/\s*5[02]\b'),
+    ('13/52', r'\b13\s*/\s*(?:5[02]|90)\b'),
     ('33/6', r'\b33\s*/\s*6\b'),
-    ('echo parentheses', r'\(\(\([^()]{1,60}\)\)\)'),
-    ('zog', r'\bzog\b'),
     ('6mwe', r'\b6mwe\b'),
+    # coded punctuation
+    ('echo parentheses', r'\(\(\([^()]{1,60}\)\)\)'),
+    # acronyms
+    ('zog', r'\bzog\b'),
+    ('wpww', r'\bwpww\b'),
+    ('gtkrwn', r'\bgtkrwn\b'),
+    ('hffh', r'\bhffh\b'),
+    ('swp', r'\bswp\b'),
+    ('klan acronym', r'\b(?:akia|ayak|kigy|klasp|itsub|kabark|lotie|ofof|fgrn)\b'),
+    # slogans and phrases
     ('great replacement', r'\bgreat\s+replacement\b'),
     ('groyper', r'\bgroypers?\b'),
     ('day of the rope', r'\bday\s+of\s+the\s+rope\b'),
     ('blood and soil', r'\bblood\s+and\s+soil\b'),
+    ('blood and honour', r'\bblood\s+(?:and|&)\s+honou?r\b'),
+    ('blut und ehre', r'\bblut\s+und\s+ehre\b'),
+    ('meine ehre heisst treue', r'\bmeine\s+ehre\s+heisst\s+treue\b'),
+    ('sieg heil', r'\bsieg\s+heil\b'),
     ('rahowa', r'\brahowa\b'),
-    ('wpww', r'\bwpww\b'),
     ('kalergi', r'\bkalergi\b'),
+    ('white genocide', r'\bwhite\s+genocide\b'),
+    ('white power', r'\bwhite\s+power\b'),
+    ('white lives matter', r'\bwhite\s+lives\s+matter\b'),
+    ('you will not replace us', r'\b(?:jews|you)\s+will\s+not\s+replace\s+us\b'),
+    ('anti-racist code word', r'\bcode\s*word\s+for\s+anti[-\s]?white\b'),
+    ("it's okay to be white", r"\bit'?s\s+ok(?:ay)?\s+to\s+be\s+white\b"),
+    ('love your race', r'\blove\s+your\s+race\b'),
+    ('race mixing', r'\brace[-\s]mixing\b'),
+    ('non silba sed anthar', r'\bnon\s+silba\b'),
+    # antisemitic meme phrases
+    ('goyim know', r'\bgoyim\s+know\b'),
+    ('anudda shoah', r'\banudda\s+shoah\b'),
+    ('muh holocaust', r'\bmuh\s+holocaust\b'),
+    ('six gorillion', r'\b(?:six|6)\s+gorillion\b'),
+    ('happy merchant', r'\bhappy\s+merchant\b'),
+    ('we wuz kangz', r'\bwe\s+wuz\s+kang[sz]\b'),
+    ('zyklon', r'\bzyklon\b'),
+    ('moonman', r'\bmoonman\b'),
+    # movement/gang identifiers plausible in text
+    ('peckerwood', r'\bpeckerwoods?\b'),
+    ('featherwood', r'\bfeatherwoods?\b'),
+    ('crazy white boy', r'\bcrazy\s+white\s+boys?\b'),
+    ('stormfront', r'\bstormfront\b'),
 )
 
 _compiled_dogwhistles = tuple(

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -14,6 +14,27 @@ def test_dogwhistle_patterns_match():
     assert '109 countries' in find_dogwhistles('kicked out of 109 countries')
 
 
+def test_dogwhistle_adl_expansion_matches():
+    assert 'sieg heil' in find_dogwhistles('and then he typed sieg heil unironically')
+    assert 'goyim know' in find_dogwhistles('the goyim know, shut it down')
+    assert 'six gorillion' in find_dogwhistles('oh no not the six gorillion')
+    assert 'white genocide' in find_dogwhistles('diversity is white genocide apparently')
+    assert 'klan acronym' in find_dogwhistles('signs off with AYAK?')
+    assert '13/52' in find_dogwhistles('posting 13/90 stats again')
+    assert '14/88' in find_dogwhistles('his handle ends in 8814')
+    assert 'we wuz kangz' in find_dogwhistles('we wuz kangs and stuff')
+    assert "it's okay to be white" in find_dogwhistles("its ok to be white posters")
+
+
+def test_dogwhistle_community_collisions_excluded():
+    # This community talks about spacecraft, weather, and electronics —
+    # these must NOT be on the watchlist.
+    assert find_dogwhistles('Orion launches next year') == []
+    assert find_dogwhistles('big storm front rolling in tonight') == []
+    assert find_dogwhistles('the moon man meme from McDonalds') == []
+    assert find_dogwhistles('found a white power supply cable') != []  # white power IS listed; adjudication decides
+
+
 def test_dogwhistle_benign_numbers_do_not_match():
     # word boundaries: 1988, 8888, and 880 must not trip the 88 pattern
     assert find_dogwhistles('back in 1988 things were different') == []


### PR DESCRIPTION
Follow-up to #115: watchlist grows 16 → ~45 patterns curated from the full ADL Hate on Display database (numeric codes, acronyms, slogans, antisemitic meme phrases), with community-collision exclusions (ORION spacecraft, weather 'storm front', bare numbers). Adjudication prompt now explicitly handles humor: jokes mocking extremists pass; irony that functions as the signal flags; ambiguous jokes go to review. Live-verified 8/8 on gemma4:12b including the PSU 'white power cable' collision. 2 new tests, 212 total.

🤖 Generated with [Claude Code](https://claude.com/claude-code)