### PR TITLE
fix: Red-team tweaks from mod-labeled false positives

### DIFF
--- a/penguin-overlord/ai/features/moderation.py
+++ b/penguin-overlord/ai/features/moderation.py
@@ -176,7 +176,8 @@ def _is_public_ip(candidate: str) -> bool:
 
 def pre_scan_pii(text: str) -> list:
     """Fast regex PII scan; returns the PII types found."""
-    text = strip_discord_syntax(text)
+    from ai.guardrails import strip_invisible
+    text = strip_discord_syntax(strip_invisible(text))
     found = []
     for name, pattern in PII_PATTERNS.items():
         if name == 'ip_address':
@@ -426,7 +427,48 @@ class ModerationAnalyzer:
             )
             if second is not None:
                 return second
+        elif result.category == 'unknown' and not result.denylist_hit:
+            # Unmapped guard S-codes (S2/S8/S14: crime, IP, code abuse) fire
+            # constantly on ordinary security-community talk ("I bypassed it
+            # entirely" -> unknown, red-team label: noise). Ask the
+            # context-capable second model; a confident 'safe' suppresses,
+            # anything else keeps the review alert (fail open).
+            cleared = await self._unknown_second_look(
+                safe_content, username, channel_name, context_messages,
+                infraction_count,
+            )
+            if cleared is not None:
+                return cleared
         return result
+
+    async def _unknown_second_look(self, safe_content, username, channel_name,
+                                   context_messages, infraction_count):
+        """Second opinion on an 'unknown' (unmapped guard code) verdict.
+        Returns a safe ModerationResult to use instead, or None to keep
+        the original review alert."""
+        model = _second_opinion_model()
+        if not model or is_guard_model(model):
+            return None
+        prompt = self._template_prompt(safe_content, username, channel_name,
+                                       context_messages, infraction_count)
+        try:
+            raw = await self._manager.generate(
+                feature='moderation', prompt=prompt,
+                system_prompt=MODERATION_SYSTEM_PROMPT, raw=True, model=model,
+            )
+        except Exception as e:
+            logger.error(f"Unknown-code second look failed: {type(e).__name__}")
+            return None
+        if not raw:
+            return None
+        second = parse_moderation_response(raw)
+        if second.is_safe and second.confidence >= 0.8:
+            return ModerationResult(
+                True, 'safe', second.confidence,
+                f"unmapped guard code cleared by second opinion ({model})",
+                'none',
+            )
+        return None
 
     @staticmethod
     def _template_prompt(safe_content: str, username: str, channel_name: str,

--- a/penguin-overlord/ai/guardrails.py
+++ b/penguin-overlord/ai/guardrails.py
@@ -184,6 +184,9 @@ _DOGWHISTLE_PATTERNS = (
     ('we wuz kangz', r'\bwe\s+wuz\s+kang[sz]\b'),
     ('zyklon', r'\bzyklon\b'),
     ('moonman', r'\bmoonman\b'),
+    # the "Jewish space lasers" meme, either word order within a short span
+    ('jewish space lasers', r'\b(?:j[e3]w\w*\W+(?:\w+\W+){0,3}space\s+lasers?|space\s+lasers?\W+(?:\w+\W+){0,3}j[e3]w\w*)\b'),
+    ('antisemitic control trope', r'\bj[e3]w\w*\s+(?:run|control|own)s?\s+(?:hollywood|the\s+media|the\s+banks|the\s+world|everything)\b'),
     # movement/gang identifiers plausible in text
     ('peckerwood', r'\bpeckerwoods?\b'),
     ('featherwood', r'\bfeatherwoods?\b'),
@@ -223,6 +226,7 @@ def find_dogwhistles(text: str) -> list:
     never 'alert' — see the moderation cog."""
     if not text:
         return []
+    text = strip_invisible(text)
     hits = [name for name, pattern in _compiled_dogwhistles if pattern.search(text)]
     hits += [name for name, pattern in _load_operator_dogwhistles()
              if pattern.search(text)]
@@ -241,8 +245,17 @@ def _normalize(text: str) -> str:
     return text
 
 
+def strip_invisible(text: str) -> str:
+    """Remove invisible format characters (zero-width spaces/joiners, BOM,
+    Mongolian vowel separator, directional marks — Unicode category Cf).
+    Red-team tested: 'Je\\u200bwi\\u200bsh' style padding blinded the regex
+    layers while remaining invisible to readers."""
+    return ''.join(c for c in text if unicodedata.category(c) != 'Cf')
+
+
 def _fold(text: str) -> str:
     """Case/accent folding only — keeps separators so boundaries survive."""
+    text = strip_invisible(text)
     text = unicodedata.normalize('NFKD', text)
     text = ''.join(c for c in text if not unicodedata.combining(c))
     return text.lower()

--- a/penguin-overlord/cogs/ai_moderation.py
+++ b/penguin-overlord/cogs/ai_moderation.py
@@ -372,6 +372,19 @@ class AIModeration(commands.Cog):
                     f"possible coded signal ({', '.join(dogwhistle_hits)}) — context unclear",
                     'review', pii,
                 )
+            elif (verdict in ('benign', 'mention')
+                  and result is not None and not result.is_safe
+                  and result.category in ('hate_speech', 'harassment')):
+                # The context-aware adjudicator overrules a context-blind
+                # model verdict on a watchlisted trope: red-team labels
+                # showed jokes QUESTIONING a trope ("but why jewish?")
+                # flagged as hate while assertions of it were confirmed.
+                logger.info('Watchlist context check (%s) overrides model %s verdict',
+                            verdict, result.category)
+                result = ModerationResult(
+                    True, 'safe', 0.8,
+                    f"watchlist context check: {verdict}", 'none', pii,
+                )
 
         if result is None or result.is_safe:
             # Regex PII on an otherwise-safe message still deserves an alert
@@ -392,10 +405,13 @@ class AIModeration(commands.Cog):
         tier = self._trust_tier(message.author)
 
         # Reclaimed in-group language: for tenured/trusted tiers a deny-list
-        # hit is adjudicated with context instead of auto-alerting — members
-        # of a marginalized group talking to each other are not attacking
-        # anyone. 'attack'/'uncertain'/model-down all still alert (fail open).
-        if result.denylist_hit and tier in self.reclaimed_tiers:
+        # hit — or a MODEL hate/harassment verdict (red-team labels: 'Bitch?'
+        # and campy queer banter flagged harassment) — is adjudicated with
+        # context instead of auto-alerting. 'attack'/'uncertain'/model-down
+        # all still alert (fail open); new users always get the strict path.
+        model_hate = (not result.denylist_hit
+                      and result.category in ('hate_speech', 'harassment'))
+        if (result.denylist_hit or model_hate) and tier in self.reclaimed_tiers:
             verdict = await self.analyzer.adjudicate(
                 'reclaimed_slur', content, message.author.display_name,
                 context_messages=list(context)[:-1],

--- a/tests/unit/test_ai_guardrails.py
+++ b/tests/unit/test_ai_guardrails.py
@@ -14,6 +14,24 @@ def test_dogwhistle_patterns_match():
     assert '109 countries' in find_dogwhistles('kicked out of 109 countries')
 
 
+def test_invisible_characters_cannot_blind_regex_layers():
+    # Red-team tested: zero-width and format characters inside terms
+    from ai.guardrails import find_blocked_terms
+    from ai.features.moderation import pre_scan_pii
+    assert find_blocked_terms('k\u200bi\u200bk\u200be') != []
+    assert find_blocked_terms('tr᠎an᠎ny') != []
+    assert '88' in find_dogwhistles('8\u200b8 my brother')
+    assert 'ssn' in pre_scan_pii('123\u200b-45-\u200b6789')
+
+
+def test_antisemitic_trope_patterns_match():
+    assert 'jewish space lasers' in find_dogwhistles('Jewish Space Lasers')
+    assert 'jewish space lasers' in find_dogwhistles('j3wish space laser time')
+    assert 'antisemitic control trope' in find_dogwhistles("the J3ws run Hollywood let's see")
+    assert 'antisemitic control trope' in find_dogwhistles('jews control the media obviously')
+    assert find_dogwhistles('jewish delis run the best pastrami game') == []
+
+
 def test_dogwhistle_adl_expansion_matches():
     assert 'sieg heil' in find_dogwhistles('and then he typed sieg heil unironically')
     assert 'goyim know' in find_dogwhistles('the goyim know, shut it down')

--- a/tests/unit/test_ai_moderation_cog.py
+++ b/tests/unit/test_ai_moderation_cog.py
@@ -319,6 +319,50 @@ async def test_denylist_takes_precedence_over_dogwhistle(tier_cog):
     assert len(detections) == 1
 
 
+# -- red-team tweak coverage -------------------------------------------------
+
+async def test_watchlist_benign_verdict_overrides_model_hate(tier_cog):
+    # 'SPACE LASERS but why jewish?' — model flags hate, context adjudicator
+    # says benign -> suppressed (mods labeled this class false positive)
+    tier_cog.analyzer = RecordingAnalyzer(
+        ModerationResult(False, 'hate_speech', 0.85, 'guard model verdict: unsafe (S10)', 'review'),
+        verdicts={'dogwhistle': 'benign'})
+    detections = await run_scan(tier_cog, tenured_message(
+        2, content='jewish space lasers, but why jewish? america has enough of its own'))
+    assert 'dogwhistle' in tier_cog.analyzer.adjudications
+    assert detections == []
+
+
+async def test_watchlist_hateful_assertion_still_alerts(tier_cog):
+    tier_cog.analyzer = RecordingAnalyzer(
+        ModerationResult(False, 'hate_speech', 0.85, 'guard model verdict: unsafe (S10)', 'review'),
+        verdicts={'dogwhistle': 'hateful'})
+    detections = await run_scan(tier_cog, tenured_message(
+        2, content='jewish space lasers are real, wake up'))
+    assert len(detections) == 1
+    assert detections[0][0].category == 'hate_speech'
+
+
+async def test_model_harassment_adjudicated_for_tenured_tiers(tier_cog):
+    # 'Bitch?' flagged harassment by the second stage; veterans get the
+    # banter check (red-team label: false positive)
+    tier_cog.analyzer = RecordingAnalyzer(
+        ModerationResult(False, 'harassment', 0.9, 'second opinion', 'review'),
+        verdicts={'reclaimed_slur': 'banter'})
+    detections = await run_scan(tier_cog, tenured_message(400, content='Bitch? lmao'))
+    assert 'reclaimed_slur' in tier_cog.analyzer.adjudications
+    assert detections == []
+
+
+async def test_model_harassment_still_alerts_for_new_users(tier_cog):
+    tier_cog.analyzer = RecordingAnalyzer(
+        ModerationResult(False, 'harassment', 0.9, 'second opinion', 'review'),
+        verdicts={'reclaimed_slur': 'banter'})
+    detections = await run_scan(tier_cog, tenured_message(2, content='Bitch? lmao'))
+    assert tier_cog.analyzer.adjudications == []
+    assert len(detections) == 1
+
+
 # -- edited-message scanning -------------------------------------------------
 
 def make_edit_payload(content='now with a slur', message=None, cached=None,

--- a/tests/unit/test_moderation.py
+++ b/tests/unit/test_moderation.py
@@ -380,6 +380,38 @@ async def test_second_opinion_guard_model_refused(monkeypatch):
     assert r.is_safe and len(manager.calls) == 1
 
 
+SECOND_SAFE = ("SAFE: true\nCATEGORY: safe\nCONFIDENCE: 0.95\n"
+               "REASON: normal security discussion\nACTION: none\nPII: none")
+
+
+async def test_unknown_guard_code_cleared_by_second_opinion(monkeypatch):
+    # 'I bypassed it entirely' -> guard S8/S14 -> unknown review alert;
+    # a confident safe from the second model suppresses (red-team: noise)
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma4:12b')
+    analyzer = ModerationAnalyzer(TwoStageManager('unsafe\nS8', SECOND_SAFE))
+    r = await analyzer.analyze('I bypassed it entirely already', 'x')
+    assert r.is_safe
+    assert 'second opinion' in r.reason
+
+
+async def test_unknown_guard_code_kept_when_second_agrees_unsafe(monkeypatch):
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma4:12b')
+    unsafe_second = SECOND_SAFE.replace('true', 'false').replace('safe', 'social_engineering')
+    analyzer = ModerationAnalyzer(TwoStageManager('unsafe\nS8', unsafe_second))
+    r = await analyzer.analyze('give me your password real quick', 'x')
+    assert not r.is_safe and r.category == 'unknown'
+
+
+async def test_unknown_guard_code_kept_without_second_model(monkeypatch):
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.delenv('AI_MODERATION_SECOND_MODEL', raising=False)
+    analyzer = ModerationAnalyzer(TwoStageManager('unsafe\nS8', SECOND_SAFE))
+    r = await analyzer.analyze('I bypassed it entirely already', 'x')
+    assert not r.is_safe and r.category == 'unknown'
+
+
 # -- guard-model prompt isolation --------------------------------------------
 
 async def test_guard_model_gets_bare_content_only(monkeypatch):


### PR DESCRIPTION
Analyzed the dry-run labels from mod testing. Fixes: invisible-character evasion (zero-width chars blinded every regex layer), watchlist context override (adjudicator beats context-blind model on tropes → 'work on dog whistles' stops alerting), model hate/harassment adjudicated for reclaimed tiers ('Bitch?' from a veteran), unmapped guard S-codes get a second look ('I bypassed it entirely' security talk), and antisemitic-trope regexes (Jewish space lasers either order). Public-figure addresses and antisemitic jokes stay human-review (fail-open on 'uncertain' — correct conservative default). 5/5 real FPs fixed, real attacks still caught. 227 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)