### PR TITLE
feat: one logging configuration, and rotation that does not depend on the host

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,13 @@ DOPPLER_CONFIG=prd
 # Optional: Logging level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
 LOG_LEVEL=INFO
 
+# Optional: also write logs to a file, with in-process rotation. Leave unset
+# under Docker — the json-file driver rotates there (see docs/reference/LOGGING.md).
+# Set it for bare-metal runs, where nothing else would cap the size.
+# LOG_FILE=/var/log/penguin-overlord/bot.log
+# LOG_MAX_BYTES=10485760   # rotate at 10 MB
+# LOG_BACKUPS=5            # keep 5 rotated files (~60 MB total)
+
 # ===========================================================================
 # AUTO-POSTING CHANNEL CONFIGURATION (All Optional)
 # ===========================================================================

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ Complete documentation lives in the [`docs/`](docs/) directory:
 - 🛡️ **[AI Moderation Guide](docs/features/AI_MODERATION.md)**
 - 📰 **[News System Guide](docs/features/NEWS_SYSTEM.md)**
 - ⚙️ **[Channel Configuration](docs/reference/CHANNEL_CONFIGURATION.md)**
+- 🪵 **[Logging & rotation](docs/reference/LOGGING.md)**
 - 🚢 **[Production Deployment](docs/deployment/PRODUCTION.md)** · [systemd](docs/deployment/SYSTEMD.md)
 
 ## 🔐 Secret Management

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,12 +49,15 @@ services:
         reservations:
           cpus: '0.25'
           memory: 128M
-    # Optional: Logging configuration
+    # Log rotation. Not optional: without it the json-file driver grows
+    # until the disk does. 20MB x 5 keeps roughly a week of a busy server's
+    # logs at ~100MB. LOG_FILE in .env adds in-process rotation instead,
+    # for bare-metal runs where there is no Docker driver to do it.
     logging:
       driver: "json-file"
       options:
-        max-size: "10m"
-        max-file: "3"
+        max-size: "20m"
+        max-file: "5"
 
 # Named volumes for data persistence
 volumes:

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,6 +31,7 @@
 - **[RSS Feeds](reference/RSS_FEEDS.md)** - Complete feed list and API information
 - **[News Optimization](reference/NEWS_OPTIMIZATION.md)** - Performance tuning guide
 - **[Help System](reference/HELP_SYSTEM.md)** - Using the categorized help system
+- **[Logging](reference/LOGGING.md)** - Log levels, rotation, and what to grep for
 
 ### 🔄 Migration & Updates
 - **[November 2025 Breaking Changes](migration/NOVEMBER_2025_BREAKING_CHANGES.md)** - Important updates

--- a/docs/reference/LOGGING.md
+++ b/docs/reference/LOGGING.md
@@ -1,0 +1,78 @@
+# Logging and log rotation
+
+Every entry point — the bot and the five one-shot runners — configures
+logging through `utils/logging_setup.py`. Nothing else calls
+`basicConfig`, and `bot.run()` is passed `log_handler=None` so discord.py
+does not install a second root handler of its own.
+
+## Settings
+
+| Variable | Default | What it does |
+|---|---|---|
+| `LOG_LEVEL` | `INFO` | Root level. `DEBUG` for feed parsing and model prompts. An unrecognised value falls back to `INFO` rather than failing to start. |
+| `LOG_FILE` | unset | Also write to this path, with in-process rotation. Leave unset in Docker — the daemon rotates instead. |
+| `LOG_MAX_BYTES` | `10485760` (10 MB) | Rotate the file at this size. |
+| `LOG_BACKUPS` | `5` | Rotated files to keep, so ~60 MB at the defaults. |
+
+Stdout logging is always on, whatever else is configured, so
+`docker logs` and `journalctl` are never empty.
+
+Third-party loggers are pinned to WARNING: `httpx`, `httpcore`,
+`urllib3`, `aiohttp.access`, `asyncio`, `discord.http`, `discord.state`,
+`websockets`. `httpx` alone logged a line per model call — two per scanned
+message — which buried the moderation records it sat between.
+
+## Rotation
+
+Rotation lives in one of two places, depending on how you run the bot.
+
+**Docker (the normal deployment).** The json-file driver rotates, set
+explicitly on the container so it does not depend on the host's
+`daemon.json`:
+
+```
+--log-driver json-file --log-opt max-size=20m --log-opt max-file=5
+```
+
+That is in `scripts/install-systemd.sh` and `docker-compose.yml`, and caps
+the bot at ~100 MB. A host-wide default is still worth setting, since it
+covers every other container too:
+
+```json
+/etc/docker/daemon.json
+{ "log-driver": "json-file", "log-opts": { "max-size": "50m", "max-file": "3" } }
+```
+
+An existing deployment picks up the new flags at the next
+`systemctl restart penguin-overlord` **after** the unit file is updated —
+re-run `scripts/install-systemd.sh`, or edit the `ExecStart` line and
+`systemctl daemon-reload`.
+
+**Bare metal.** No Docker driver, so set `LOG_FILE` and the in-process
+`RotatingFileHandler` does the same job:
+
+```env
+LOG_FILE=/var/log/penguin-overlord/bot.log
+LOG_MAX_BYTES=20971520
+LOG_BACKUPS=5
+```
+
+The one-shot news and comic timers run attached under systemd, so their
+output lands in journald and is bounded by `SystemMaxUse` in
+`/etc/systemd/journald.conf` (10% of the filesystem by default). If those
+timers dominate your journal, `journalctl --disk-usage` will show it.
+
+## Reading the logs
+
+```bash
+docker logs -f penguin-overlord                    # live
+docker logs --since 2h penguin-overlord            # recent
+journalctl -u penguin-overlord --since today       # systemd's view
+
+# moderation review clicks: arrival, then resolution with latency
+docker logs --since 24h penguin-overlord | grep -E 'Review button|Review .* resolved'
+```
+
+A missing `Review button ... clicked` line for a click a moderator says
+they made means the interaction never reached the bot — a delivery
+problem, not a handler problem. That distinction is why the line exists.

--- a/penguin-overlord/bot.py
+++ b/penguin-overlord/bot.py
@@ -8,7 +8,6 @@ Main bot entry point.
 """
 
 import os
-import logging
 from pathlib import Path
 import discord
 from discord.ext import commands
@@ -16,13 +15,9 @@ from dotenv import load_dotenv
 
 # Import secrets management
 from utils.secrets import get_secret
+from utils.logging_setup import configure_logging, describe_logging
 
-# Set up logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger(__name__)
+logger = configure_logging('bot')
 
 # Load environment variables (fallback if not using secrets manager)
 load_dotenv()
@@ -60,20 +55,26 @@ class PenguinOverlord(commands.Bot):
     async def setup_hook(self):
         """Load extensions/cogs when bot starts."""
         logger.info("Loading extensions...")
-        
+
         # Load all cogs from the cogs directory
+        loaded, failed = [], []
         cogs_path = Path(__file__).parent / 'cogs'
         if cogs_path.exists():
             for file in cogs_path.glob('*.py'):
                 if file.name.startswith('_'):
                     continue
-                
+
                 try:
                     await self.load_extension(f'cogs.{file.stem}')
+                    loaded.append(file.stem)
                     logger.info(f"✓ Loaded extension: {file.stem}")
                 except Exception as e:
-                    logger.error(f"✗ Failed to load extension {file.stem}: {e}")
-    
+                    failed.append(file.stem)
+                    # exc_info: a bare message hid which import actually broke
+                    logger.error(f"✗ Failed to load extension {file.stem}: {e}", exc_info=e)
+        logger.info('Extensions: %d loaded, %d failed%s', len(loaded), len(failed),
+                    f" ({', '.join(failed)})" if failed else '')
+
     async def on_ready(self):
         """Called when the bot is ready."""
         logger.info(f'🐧 {self.user} has connected to Discord!')
@@ -131,10 +132,14 @@ def main():
         logger.error("See .env.example for reference.")
         return
     
+    logger.info('Penguin Overlord starting — logging %s', describe_logging())
+
     bot = PenguinOverlord()
-    
+
     try:
-        bot.run(token)
+        # log_handler=None: discord.py otherwise installs its own root
+        # handler alongside ours and every discord.* record is logged twice.
+        bot.run(token, log_handler=None)
     except discord.LoginFailure:
         logger.error("❌ Invalid Discord bot token!")
     except Exception as e:

--- a/penguin-overlord/comics_runner.py
+++ b/penguin-overlord/comics_runner.py
@@ -20,7 +20,6 @@ Environment Variables:
 import os
 import sys
 import asyncio
-import logging
 import re
 from pathlib import Path
 from datetime import datetime
@@ -37,17 +36,11 @@ load_dotenv()
 
 # Import secrets utility
 from utils.secrets import get_secret
+from utils.logging_setup import configure_logging
 from utils.state import load_json_state, save_json_state
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger('comics_runner')
+logger = configure_logging('comics_runner')
 
 
 DATA_DIR = os.getenv('DATA_DIR') or ('/app/data' if os.path.exists('/app/data') else 'data')

--- a/penguin-overlord/kev_runner.py
+++ b/penguin-overlord/kev_runner.py
@@ -20,7 +20,6 @@ Environment Variables:
 import os
 import sys
 import asyncio
-import logging
 import re
 import xml.etree.ElementTree as ET
 import defusedxml.ElementTree as DET  # hardened parser for untrusted feed XML
@@ -36,20 +35,14 @@ from dotenv import load_dotenv
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from utils.secrets import get_secret
+from utils.logging_setup import configure_logging
 from utils.state import load_json_state, save_json_state
 
 # Load environment
 load_dotenv()
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger('kev_runner')
+logger = configure_logging('kev_runner')
 
 
 STATE_FILE = Path('data/kev_state.json')

--- a/penguin-overlord/news_runner.py
+++ b/penguin-overlord/news_runner.py
@@ -39,14 +39,12 @@ sys.path.insert(0, str(project_root / "penguin-overlord"))
 import discord
 from discord.ext import commands
 from utils.news_fetcher import OptimizedNewsFetcher
+from utils.logging_setup import configure_logging
 from utils.secrets import get_secret
 
-# Configure logging - will be set to DEBUG if --verbose flag is used
-logging.basicConfig(
-    level=logging.DEBUG,  # Default to DEBUG so we can see HTML stripping
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
-)
-logger = logging.getLogger(__name__)
+# INFO by default; --verbose (or LOG_LEVEL=DEBUG) turns on the HTML-stripping
+# detail this used to log unconditionally, on every timer run, forever.
+logger = configure_logging('news_runner')
 
 
 class StandaloneNewsRunner:
@@ -267,8 +265,14 @@ async def main():
         choices=['cybersecurity', 'tech', 'gaming', 'apple_google', 'cve', 'kev', 'us_legislation', 'eu_legislation', 'uk_legislation', 'general_news', 'vendor_alerts'],
         help='News category to fetch'
     )
+    parser.add_argument(
+        '--verbose', action='store_true',
+        help='DEBUG logging (feed parsing, HTML stripping)',
+    )
     args = parser.parse_args()
-    
+    if args.verbose:
+        configure_logging('news_runner', level=logging.DEBUG)
+
     logger.info(f"Starting news runner for category: {args.category}")
     
     runner = StandaloneNewsRunner(args.category)

--- a/penguin-overlord/solar_runner.py
+++ b/penguin-overlord/solar_runner.py
@@ -22,7 +22,6 @@ Environment Variables:
 import os
 import sys
 import asyncio
-import logging
 from pathlib import Path
 from datetime import datetime, timezone
 
@@ -306,17 +305,11 @@ load_dotenv()
 
 # Import secrets utility
 from utils.secrets import get_secret
+from utils.logging_setup import configure_logging
 from utils.state import load_json_state, save_json_state
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger('solar_runner')
+logger = configure_logging('solar_runner')
 
 
 STATE_FILE = Path('data/solar_state.json')

--- a/penguin-overlord/utils/logging_setup.py
+++ b/penguin-overlord/utils/logging_setup.py
@@ -1,0 +1,120 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""One logging configuration for every entry point.
+
+The bot and the five one-shot runners each used to call `basicConfig`
+themselves, at different levels (news_runner defaulted to DEBUG), and
+`bot.run()` additionally installed discord.py's own root handler on top —
+so every `discord.*` record was emitted twice. This module replaces all of
+that with a single `configure_logging()` call.
+
+Rotation is handled in two places, deliberately:
+
+- **Container (normal deployment):** the Docker json-file driver rotates,
+  configured on the `docker run` in the systemd unit and in
+  docker-compose.yml. Logs stay in `docker logs` / journald where the rest
+  of the host's logs are.
+- **Bare metal or when you want a file:** set `LOG_FILE` and a
+  `RotatingFileHandler` takes over the same rotation job in-process.
+
+Never both by accident: a file handler is added only when `LOG_FILE` is
+set, and stdout logging always stays on so `docker logs` is never empty.
+"""
+
+import logging
+import logging.handlers
+import os
+from pathlib import Path
+
+# Third-party loggers that are useful at WARNING and pure noise at INFO.
+# httpx logs a line per request: with two model calls per scanned message
+# that buried the bot's own records in the moderation logs.
+_NOISY = {
+    'httpx': logging.WARNING,
+    'httpcore': logging.WARNING,
+    'urllib3': logging.WARNING,
+    'aiohttp.access': logging.WARNING,
+    'asyncio': logging.WARNING,
+    'discord.http': logging.WARNING,
+    'discord.state': logging.WARNING,
+    'websockets': logging.WARNING,
+}
+
+_FORMAT = '%(asctime)s %(levelname)-8s %(name)s: %(message)s'
+_DATEFMT = '%Y-%m-%d %H:%M:%S'
+
+# Marks the handlers this module owns, so repeat calls replace their own
+# work instead of stacking duplicates on top of it.
+_OWNED = '_penguin_logging'
+
+DEFAULT_MAX_BYTES = 10 * 1024 * 1024   # 10 MB per file
+DEFAULT_BACKUPS = 5                    # ~60 MB ceiling with the default size
+
+
+def _level(name: str, default: int = logging.INFO) -> int:
+    raw = (os.getenv(name) or '').strip().upper()
+    if not raw:
+        return default
+    resolved = logging.getLevelName(raw)
+    return resolved if isinstance(resolved, int) else default
+
+
+def configure_logging(component: str = 'penguin', *, level: int = None) -> logging.Logger:
+    """Install stdout logging (plus a rotating file when LOG_FILE is set).
+
+    Env:
+        LOG_LEVEL     root level, default INFO (DEBUG/INFO/WARNING/...)
+        LOG_FILE      path to also write to; enables in-process rotation
+        LOG_MAX_BYTES rotate at this size, default 10 MB
+        LOG_BACKUPS   keep this many rotated files, default 5
+
+    Returns the component's logger. Safe to call more than once.
+    """
+    root = logging.getLogger()
+    for handler in [h for h in root.handlers if getattr(h, _OWNED, False)]:
+        root.removeHandler(handler)
+        handler.close()
+
+    root.setLevel(level if level is not None else _level('LOG_LEVEL'))
+    formatter = logging.Formatter(_FORMAT, datefmt=_DATEFMT)
+
+    stream = logging.StreamHandler()
+    stream.setFormatter(formatter)
+    setattr(stream, _OWNED, True)
+    root.addHandler(stream)
+
+    log_file = (os.getenv('LOG_FILE') or '').strip()
+    if log_file:
+        try:
+            Path(log_file).parent.mkdir(parents=True, exist_ok=True)
+            file_handler = logging.handlers.RotatingFileHandler(
+                log_file,
+                maxBytes=int(os.getenv('LOG_MAX_BYTES') or DEFAULT_MAX_BYTES),
+                backupCount=int(os.getenv('LOG_BACKUPS') or DEFAULT_BACKUPS),
+                encoding='utf-8',
+            )
+            file_handler.setFormatter(formatter)
+            setattr(file_handler, _OWNED, True)
+            root.addHandler(file_handler)
+        except OSError as e:
+            # An unwritable LOG_FILE must never stop the bot from starting;
+            # stdout logging is already in place to carry the complaint.
+            root.warning('LOG_FILE %s is not writable (%s) — stdout only', log_file, e)
+
+    for name, noisy_level in _NOISY.items():
+        logging.getLogger(name).setLevel(noisy_level)
+
+    return logging.getLogger(component)
+
+
+def describe_logging() -> str:
+    """One-line summary for the startup banner."""
+    root = logging.getLogger()
+    sinks = ['stdout']
+    for handler in root.handlers:
+        if isinstance(handler, logging.handlers.RotatingFileHandler):
+            sinks.append(f'{handler.baseFilename} '
+                         f'(rotate {handler.maxBytes // (1024 * 1024)}MB x{handler.backupCount})')
+    return f"level={logging.getLevelName(root.level)} sinks={', '.join(sinks)}"

--- a/penguin-overlord/xkcd_runner.py
+++ b/penguin-overlord/xkcd_runner.py
@@ -20,7 +20,6 @@ Environment Variables:
 import os
 import sys
 import asyncio
-import logging
 from pathlib import Path
 
 import discord
@@ -35,17 +34,11 @@ load_dotenv()
 
 # Import secrets utility
 from utils.secrets import get_secret
+from utils.logging_setup import configure_logging
 from utils.state import load_json_state, save_json_state
 
 # Configure logging
-logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
-    handlers=[
-        logging.StreamHandler()
-    ]
-)
-logger = logging.getLogger('xkcd_runner')
+logger = configure_logging('xkcd_runner')
 
 
 # Prefer mounted data directory (Docker) or user-specified DATA_DIR, fallback to local data/

--- a/scripts/install-systemd.sh
+++ b/scripts/install-systemd.sh
@@ -260,7 +260,7 @@ RemainAfterExit=yes
 User=$ACTUAL_USER
 Group=$ACTUAL_USER
 WorkingDirectory=$PROJECT_DIR
-ExecStart=/usr/bin/docker run -d --name penguin-overlord --restart unless-stopped --env-file $PROJECT_DIR/.env -v $PROJECT_DIR/events:/app/events:ro -v $PROJECT_DIR/data:/app/data $IMAGE_NAME
+ExecStart=/usr/bin/docker run -d --name penguin-overlord --restart unless-stopped --log-driver json-file --log-opt max-size=20m --log-opt max-file=5 --env-file $PROJECT_DIR/.env -v $PROJECT_DIR/events:/app/events:ro -v $PROJECT_DIR/data:/app/data $IMAGE_NAME
 ExecStop=/usr/bin/docker stop penguin-overlord
 ExecStopPost=/usr/bin/docker rm -f penguin-overlord
 StandardOutput=journal

--- a/tests/unit/test_logging_setup.py
+++ b/tests/unit/test_logging_setup.py
@@ -1,0 +1,137 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for utils/logging_setup.py.
+
+Logging is shared by six entry points, so the failure modes worth pinning
+are the ones that are invisible until you read a week of logs: duplicated
+records, a level that silently ignores the environment, and a file handler
+that grows without bound.
+"""
+
+import logging
+import logging.handlers
+
+import pytest
+
+from utils.logging_setup import configure_logging, describe_logging
+
+
+@pytest.fixture(autouse=True)
+def restore_root_logging():
+    root = logging.getLogger()
+    saved = list(root.handlers), root.level
+    yield
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    for handler in saved[0]:
+        root.addHandler(handler)
+    root.setLevel(saved[1])
+
+
+def _owned(root):
+    return [h for h in root.handlers if getattr(h, '_penguin_logging', False)]
+
+
+def test_configures_stdout_at_info_by_default(monkeypatch):
+    monkeypatch.delenv('LOG_LEVEL', raising=False)
+    monkeypatch.delenv('LOG_FILE', raising=False)
+    logger = configure_logging('bot')
+
+    root = logging.getLogger()
+    assert root.level == logging.INFO
+    assert len(_owned(root)) == 1
+    assert logger.name == 'bot'
+
+
+def test_repeat_calls_do_not_duplicate_handlers(monkeypatch):
+    monkeypatch.delenv('LOG_FILE', raising=False)
+    configure_logging('bot')
+    configure_logging('bot')
+    configure_logging('news_runner')
+    # Every record would otherwise be emitted once per call — which is the
+    # bug that made discord.py's own handler double the bot's output.
+    assert len(_owned(logging.getLogger())) == 1
+
+
+def test_level_comes_from_environment(monkeypatch):
+    monkeypatch.setenv('LOG_LEVEL', 'debug')
+    configure_logging('bot')
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_nonsense_level_falls_back_to_info(monkeypatch):
+    monkeypatch.setenv('LOG_LEVEL', 'chatty')
+    configure_logging('bot')
+    assert logging.getLogger().level == logging.INFO
+
+
+def test_explicit_level_beats_environment(monkeypatch):
+    monkeypatch.setenv('LOG_LEVEL', 'WARNING')
+    configure_logging('news_runner', level=logging.DEBUG)
+    assert logging.getLogger().level == logging.DEBUG
+
+
+def test_noisy_third_party_loggers_are_quieted(monkeypatch):
+    monkeypatch.delenv('LOG_FILE', raising=False)
+    configure_logging('bot')
+    # httpx logs a line per request; two model calls per scanned message
+    # buried the moderation records underneath them.
+    assert logging.getLogger('httpx').level == logging.WARNING
+    assert logging.getLogger('discord.http').level == logging.WARNING
+
+
+def test_log_file_gets_a_rotating_handler(monkeypatch, tmp_path):
+    target = tmp_path / 'logs' / 'bot.log'
+    monkeypatch.setenv('LOG_FILE', str(target))
+    monkeypatch.setenv('LOG_MAX_BYTES', '2048')
+    monkeypatch.setenv('LOG_BACKUPS', '3')
+    configure_logging('bot')
+
+    handlers = [h for h in _owned(logging.getLogger())
+                if isinstance(h, logging.handlers.RotatingFileHandler)]
+    assert len(handlers) == 1
+    assert handlers[0].maxBytes == 2048
+    assert handlers[0].backupCount == 3
+    assert target.parent.exists()
+    # stdout logging survives alongside it, so `docker logs` is never empty
+    assert len(_owned(logging.getLogger())) == 2
+
+
+def test_rotation_actually_caps_the_file(monkeypatch, tmp_path):
+    target = tmp_path / 'bot.log'
+    monkeypatch.setenv('LOG_FILE', str(target))
+    monkeypatch.setenv('LOG_MAX_BYTES', '1024')
+    monkeypatch.setenv('LOG_BACKUPS', '2')
+    logger = configure_logging('bot')
+
+    for i in range(200):
+        logger.info('a padded line to force rotation %03d %s', i, 'x' * 60)
+
+    rotated = sorted(p.name for p in tmp_path.iterdir())
+    assert rotated == ['bot.log', 'bot.log.1', 'bot.log.2']
+    for path in tmp_path.iterdir():
+        assert path.stat().st_size < 4096, path
+
+
+def test_unwritable_log_file_does_not_stop_startup(monkeypatch, tmp_path):
+    blocker = tmp_path / 'not-a-dir'
+    blocker.write_text('')
+    monkeypatch.setenv('LOG_FILE', str(blocker / 'bot.log'))
+    logger = configure_logging('bot')
+
+    assert logger.name == 'bot'
+    assert len(_owned(logging.getLogger())) == 1  # stdout only, still running
+
+
+def test_describe_logging_names_the_sinks(monkeypatch, tmp_path):
+    monkeypatch.setenv('LOG_FILE', str(tmp_path / 'bot.log'))
+    monkeypatch.setenv('LOG_MAX_BYTES', str(5 * 1024 * 1024))
+    monkeypatch.setenv('LOG_BACKUPS', '4')
+    configure_logging('bot')
+
+    summary = describe_logging()
+    assert 'level=INFO' in summary
+    assert 'stdout' in summary
+    assert 'rotate 5MB x4' in summary


### PR DESCRIPTION
## What was wrong

- **Every `discord.*` record was logged twice.** Six entry points each called
  `basicConfig`, and `bot.run()` additionally let discord.py install its own
  root handler alongside ours. Visible in production: the same gateway RESUME
  line appearing in both a coloured and a plain format.
- **`news_runner` ran at DEBUG permanently** — "Default to DEBUG so we can see
  HTML stripping", on every timer run, forever. 96,699 journal lines mention
  penguin in the last 7 days on the live box.
- **`httpx` logged a line per model call** — two per scanned message — in
  between the moderation records they buried.
- **`LOG_LEVEL` was documented in `.env.example` and read by nothing.**
- **Rotation was inherited, not declared.** The live host happens to have
  sensible `daemon.json` defaults (50m x3); a fresh host gets Docker's
  unbounded default and nothing in this repo says otherwise.

## What this does

`utils/logging_setup.py` is now the only logging configuration:

- one stdout handler, consistent format, `LOG_LEVEL` honoured — falling back
  to INFO on a typo rather than failing to start
- `bot.run(token, log_handler=None)`, ending the double-logging
- noisy third-party loggers pinned to WARNING (`httpx`, `httpcore`, `urllib3`,
  `aiohttp.access`, `asyncio`, `discord.http`, `discord.state`, `websockets`)
- `LOG_FILE` adds a `RotatingFileHandler` (`LOG_MAX_BYTES` / `LOG_BACKUPS`,
  10 MB x5 by default) for bare-metal runs. stdout logging stays on whatever
  else is set, so `docker logs` is never empty, and an unwritable `LOG_FILE`
  warns instead of stopping startup.
- `news_runner --verbose` — the flag its comment already claimed existed

Rotation for the container deployment is declared on the container itself
(`--log-opt max-size=20m --log-opt max-file=5`, ~100 MB ceiling) in
`install-systemd.sh` and `docker-compose.yml`.

Also: extension load failures now log `exc_info` (a bare message hid which
import actually broke), and startup reports its level and sinks.

## Verification

- 317 unit tests pass, 10 new — including one that writes 200 lines through a
  1 KB limit and asserts the files on disk are `bot.log`, `.1`, `.2` and all
  under 4 KB, so rotation is tested rather than assumed
- all six entry points import with exactly one handler at INFO (checked
  directly, not inferred)
- ruff clean

**One manual step on an existing box:** the running unit still carries the old
`ExecStart`. Re-run `scripts/install-systemd.sh`, or edit the line and
`systemctl daemon-reload` — that needs your sudo, so I have not done it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)