### PR TITLE
feat: newcomer helper — point new members at the resources channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,20 @@ DOPPLER_CONFIG=prd
 # ============================================================================
 # General Settings
 # ============================================================================
+# ---------------------------------------------------------------------------
+# Newcomer helper — points new members at your resources channel when they
+# ask where to start. See docs/features/NEWCOMER_HELPER.md
+# ---------------------------------------------------------------------------
+# HELPER_ENABLED=false
+# HELPER_CHANNELS=                    # REQUIRED allowlist of channel IDs
+# HELPER_RESOURCE_CHANNEL_ID=         # REQUIRED — the channel to point at
+# HELPER_RULES_CHANNEL_ID=            # optional second channel
+# HELPER_TIERS=new                    # trust tiers eligible for the nudge
+# HELPER_COOLDOWN_SECONDS=60          # per-channel quiet period
+# HELPER_USER_COOLDOWN_SECONDS=1800   # per-person quiet period
+# HELPER_USE_LLM=true                 # second model can veto a weak match
+# HELPER_MESSAGE=Welcome {user}! Please read {rules} and start with {resources}.
+
 # Optional: community profile(s) — what counts as normal talk in this server.
 # Combine with commas; every listed topic becomes on-topic. Profiles never
 # relax hate speech, harassment, self-harm, or sexual content.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,8 @@
 
 ### ✨ Features
 - **[AI Features](features/AI_MODERATION.md)** - Ollama-backed Arch roasts and alert-first AI moderation
+- **[Newcomer Helper](features/NEWCOMER_HELPER.md)** - points new members at your resources channel
+- **[Role Management Notes](features/ROLE_MANAGEMENT_NOTES.md)** - future work: what taking over from MEE6 would involve
 - **[News System](features/NEWS_SYSTEM.md)** - 92 sources across 8 categories
 - **[News Categories](features/NEWS_CATEGORIES_OVERVIEW.md)** - Detailed category breakdown
 

--- a/docs/features/NEWCOMER_HELPER.md
+++ b/docs/features/NEWCOMER_HELPER.md
@@ -1,0 +1,76 @@
+# Newcomer helper
+
+"Where do I start with this?" gets asked constantly in a learning-oriented
+server, usually by someone who has not found the pinned channels yet. This
+answers once, politely, and then gets out of the way.
+
+The governing constraint is the same one moderation runs on: **a false
+positive is expensive**. A bot that replies to messages that were not
+questions is worse than one that stays quiet, because members learn to tune
+it out. Everything below exists to make silence the default.
+
+## Configuration
+
+```env
+HELPER_ENABLED=true
+HELPER_CHANNELS=123,456              # REQUIRED allowlist — empty watches nothing
+HELPER_RESOURCE_CHANNEL_ID=789       # REQUIRED — the channel to point at
+HELPER_RULES_CHANNEL_ID=012          # optional second channel
+HELPER_TIERS=new                     # trust tiers eligible for the nudge
+HELPER_COOLDOWN_SECONDS=60           # per-channel quiet period
+HELPER_USER_COOLDOWN_SECONDS=1800    # per-person quiet period
+HELPER_MIN_LENGTH=12                 # ignore very short messages
+HELPER_USE_LLM=true                  # let the second model veto a weak match
+HELPER_MESSAGE=                      # template; see below
+```
+
+With `HELPER_ENABLED=true` but no allowlist or no resource channel, the cog
+logs an error and disables itself rather than guessing.
+
+### The message
+
+Default:
+
+> Welcome {user}! Please have a look at {rules}, and {resources} is the best
+> place to start.
+
+Placeholders: `{user}` (a mention), `{resources}`, `{rules}` (channel
+mentions), and `{rules_clause}` — the "Please have a look at …, and " phrase,
+which disappears when no rules channel is configured. Set your own with
+`HELPER_MESSAGE`; a template referencing an unknown placeholder falls back to
+the default wording rather than silencing the feature.
+
+```env
+HELPER_MESSAGE=Welcome {user}! Please read {rules} and start with {resources}.
+```
+
+## How a message qualifies
+
+1. **Tier** — only `HELPER_TIERS` (default `new`, meaning under
+   `MOD_MEMBER_DAYS`). A two-year regular asking where to start is just
+   conversation. Tiers come from the same `utils/trust.py` moderation uses,
+   so one member is one tier everywhere.
+2. **Pattern** — a deterministic regex must match a request for *direction*
+   ("where do I start", "any good resources", "point me in the right
+   direction"). Merely containing "learn" or "resources" is not enough:
+   *"i learned that the hard way"* and *"here are some resources I put
+   together"* do not match.
+3. **Not a support question** — "any resources on why my nmap scan fails"
+   wants a human with an answer, not a signpost, so specific-problem
+   phrasing (error, traceback, not working, why is my …) disqualifies it.
+4. **Cooldowns** — one per channel so the bot never chatters, one per person
+   so nobody gets followed around.
+5. **Model veto** (optional) — the second-stage model can overrule a
+   borderline pattern match. When it is unavailable the regex match stands:
+   a downed model must not silently switch the feature off.
+
+Only steps 4 and 5 cost anything beyond a regex, and step 5 only runs on
+messages that already matched.
+
+Verified against the live models: 6/6 on a hand-built set, including the two
+that must stay quiet (*"here are some resources i put together for you all"*
+and *"any resources on why my nmap scan fails to resolve"*).
+
+Replies are counted in `penguin_helper_replies_total`, never ping the room
+(`@everyone`/roles are disabled), and do not force a reply-ping on the
+author.

--- a/docs/features/ROLE_MANAGEMENT_NOTES.md
+++ b/docs/features/ROLE_MANAGEMENT_NOTES.md
@@ -1,0 +1,65 @@
+# Role and engagement management — future work
+
+**Status: not built. Notes only.**
+
+The server currently runs MEE6 for roles and engagement, and it hiccups —
+occasional gaps where a role is not applied, or a level-up goes missing.
+The question is whether Penguin Overlord should take some or all of that
+over, given it already has the pieces: a database, trust tiers, a metrics
+endpoint, and a deployment the operator controls.
+
+Nothing here is scheduled. This file exists so the idea is written down
+with its trade-offs instead of being rediscovered later.
+
+## What MEE6 is doing today
+
+Worth confirming against the live server before building anything, but
+broadly:
+
+- **Autorole on join** — new members get a baseline role.
+- **Reaction / self-assign roles** — pronouns, interests, ping opt-ins.
+- **Levelling** — XP per message, level-up announcements, role rewards at
+  thresholds.
+- **Some moderation** — superseded by this bot's moderation cog.
+
+## What taking it over would need
+
+| Piece | Notes |
+|---|---|
+| Autorole | `on_member_join` plus a reconciliation pass, because the failure mode that matters is the join event being *missed*. A periodic sweep that finds members lacking the baseline role is the part MEE6 apparently lacks. |
+| Self-assign roles | Persistent `discord.ui` views, which this bot already does for moderation review buttons (`DynamicItem`, custom_id-encoded state, restart-proof). |
+| Levelling | XP table in the existing SQLite database, per-message with an anti-spam cooldown. Needs a migration path: **exporting existing XP from MEE6 is the hard part**, and starting everyone from zero would be unpopular. Worth checking what their export offers before committing. |
+| Level rewards | Role grants at thresholds; must be idempotent and reconcilable for the same reason autorole is. |
+| Permissions | The bot needs Manage Roles and a role positioned above everything it grants. Worth auditing what that widens. |
+
+## Why it might be worth it
+
+- One bot, one config, one log to read when something does not happen.
+- The gaps are reconcilable: a sweep that compares intended state against
+  actual state and fixes drift is straightforward here and is exactly what
+  a hosted bot tends not to offer.
+- Trust tiers already exist and are shared (`utils/trust.py`) — tenure and
+  role classes are computed once for moderation and the newcomer helper,
+  and levelling would be a third consumer.
+
+## Why it might not
+
+- Role management is a **destructive** capability. Moderation here is
+  deliberately alert-first and dry-run by default; granting Manage Roles is
+  a different risk posture and deserves its own opt-in flags, its own audit
+  log, and probably its own dry-run mode first.
+- XP migration may simply not be possible cleanly, and a reset annoys
+  everyone who earned a level.
+- MEE6 working 95% of the time may beat a self-hosted replacement working
+  99% of the time but going down when the homelab does. The bot already
+  shares that fate for moderation, but roles failing closed is more
+  visible to ordinary members.
+
+## Suggested first step, when it comes up
+
+Not a rewrite. Add a **reconciliation-only** mode: the bot watches, reports
+what MEE6 *should* have done and did not — members missing the baseline
+role, level rewards not applied — and posts that to the mod channel without
+touching anything. That measures the size of the actual problem before
+anyone commits to owning the whole feature, and mirrors how moderation was
+introduced here (watch and report, earn trust, then enforce).

--- a/penguin-overlord/ai/features/moderation.py
+++ b/penguin-overlord/ai/features/moderation.py
@@ -712,11 +712,27 @@ class ModerationAnalyzer:
         Returns the verdict word, or 'uncertain' when no second model is
         configured, the model is down, or the answer doesn't parse —
         callers must FAIL OPEN (treat 'uncertain' as 'alert anyway')."""
+        system_prompt, allowed = self._ADJUDICATIONS[kind]
+        return await self.adjudicate_custom(
+            system_prompt, message_content, username, allowed=allowed,
+            context_messages=context_messages, note=note, kind=kind,
+        )
+
+    async def adjudicate_custom(self, system_prompt: str, message_content: str,
+                                username: str, *, allowed, kind: str = 'custom',
+                                context_messages: list = None,
+                                note: str = None) -> str:
+        """`adjudicate` with a caller-supplied question.
+
+        The same second-stage plumbing — model selection, prompt shaping,
+        verdict parsing, fail-soft — for features outside moderation that
+        need one focused judgement (the newcomer helper's 'is this person
+        actually asking where to start?').
+        """
         model = _second_opinion_model()
         if not model or is_guard_model(model):
             return 'uncertain'
 
-        system_prompt, allowed = self._ADJUDICATIONS[kind]
         prompt = self._template_prompt(
             sanitize_input(message_content, max_length=1500),
             username, '', context_messages, 0,

--- a/penguin-overlord/cogs/ai_moderation.py
+++ b/penguin-overlord/cogs/ai_moderation.py
@@ -238,21 +238,14 @@ class AIModeration(commands.Cog):
     def _trust_tier(self, member) -> str:
         """new -> member -> veteran by tenure; trusted/creator by role.
         Fully exempt users (mods) never reach here — MOD_IGNORED_ROLES
-        gates them out in _eligible()."""
-        role_ids = {r.id for r in getattr(member, 'roles', [])}
-        if role_ids & self.creator_roles:
-            return 'creator'
-        if role_ids & self.trusted_roles:
-            return 'trusted'
-        joined = getattr(member, 'joined_at', None)
-        if joined is None:
-            return 'new'
-        days = (discord.utils.utcnow() - joined).days
-        if days >= self.veteran_days:
-            return 'veteran'
-        if days >= self.member_days:
-            return 'member'
-        return 'new'
+        gates them out in _eligible(). Shared with the newcomer helper,
+        which asks the same question for a friendlier reason."""
+        from utils.trust import trust_tier
+        return trust_tier(
+            member,
+            member_days=self.member_days, veteran_days=self.veteran_days,
+            trusted_roles=self.trusted_roles, creator_roles=self.creator_roles,
+        )
 
     def _eligible(self, message) -> bool:
         """Shared gating for new and edited messages."""

--- a/penguin-overlord/cogs/ai_moderation.py
+++ b/penguin-overlord/cogs/ai_moderation.py
@@ -345,8 +345,11 @@ class AIModeration(commands.Cog):
         # Per-user cooldown applies to LLM scans only; regex hits always proceed
         now = time.monotonic()
         if run_llm and not pii and not denylist_hits and not dogwhistle_hits:
-            last = self._user_last_scan.get(message.author.id, 0)
-            if now - last < self.user_cooldown:
+            # None, not 0: time.monotonic() counts from boot, so a 0 default
+            # made every user look recently-scanned for the first
+            # MOD_USER_COOLDOWN_SECONDS after a reboot.
+            last = self._user_last_scan.get(message.author.id)
+            if last is not None and now - last < self.user_cooldown:
                 run_llm = False
             else:
                 self._user_last_scan[message.author.id] = now

--- a/penguin-overlord/cogs/newcomer_helper.py
+++ b/penguin-overlord/cogs/newcomer_helper.py
@@ -194,11 +194,19 @@ class NewcomerHelper(commands.Cog):
             )
 
     def _cooling_down(self, message, now: float) -> bool:
-        last_channel = self._channel_last.get(message.channel.id, 0)
-        if now - last_channel < self.cooldown:
+        """Never-seen must not read as just-seen.
+
+        `time.monotonic()` counts from boot, so a 0 default meant that on a
+        freshly started machine `now - 0` was smaller than the cooldown and
+        the helper stayed silent for the first minute (and half hour) of its
+        life. CI on a fresh runner found this; a rebooted homelab box would
+        have hit exactly the same thing.
+        """
+        last_channel = self._channel_last.get(message.channel.id)
+        if last_channel is not None and now - last_channel < self.cooldown:
             return True
-        last_user = self._user_last.get(message.author.id, 0)
-        return now - last_user < self.user_cooldown
+        last_user = self._user_last.get(message.author.id)
+        return last_user is not None and now - last_user < self.user_cooldown
 
     async def _confirms(self, content: str, username: str) -> bool:
         """Second-stage veto for a borderline match.

--- a/penguin-overlord/cogs/newcomer_helper.py
+++ b/penguin-overlord/cogs/newcomer_helper.py
@@ -1,0 +1,268 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Point newcomers at the resources channel when they ask where to start.
+
+"Where do I begin with this?" gets asked constantly in a learning-oriented
+server, usually by someone who has not found the pinned channels yet. This
+answers once, politely, and then gets out of the way.
+
+The design constraint is the same one that governs moderation here: a
+false positive is expensive. A bot that replies to messages that were not
+questions is worse than one that stays quiet, because members learn to
+tune it out. So:
+
+- Only members in the configured tiers (new by default) are eligible.
+- A deterministic pattern must match first — no model call on ordinary chat.
+- The second-stage model can then veto a borderline match (HELPER_USE_LLM),
+  and when the model is unavailable the deterministic match stands.
+- Two cooldowns: one per channel so the bot never chatters, one per person
+  so nobody gets followed around.
+
+Configuration (env / secrets, all HELPER_*):
+    HELPER_ENABLED=false               master switch
+    HELPER_CHANNELS=                   REQUIRED allowlist of channel IDs
+    HELPER_TIERS=new                   which trust tiers get the nudge
+    HELPER_COOLDOWN_SECONDS=60         per-channel quiet period
+    HELPER_USER_COOLDOWN_SECONDS=1800  per-person quiet period
+    HELPER_RESOURCE_CHANNEL_ID=        channel to point at
+    HELPER_RULES_CHANNEL_ID=           optional second channel (rules)
+    HELPER_MESSAGE=                    template; {user} {resources} {rules}
+    HELPER_USE_LLM=true                let the model veto a weak match
+    HELPER_MIN_LENGTH=12               ignore very short messages
+"""
+
+import logging
+import os
+import re
+import time
+
+import discord
+from discord.ext import commands
+
+from utils import metrics
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MESSAGE = (
+    "Welcome {user}! {rules_clause}{resources} is the best place to start."
+)
+
+# Deterministic first pass. Every pattern is a request for direction, not
+# merely a message containing the word "learn" — 'i learned that yesterday'
+# must not trip it.
+_ASK_PATTERNS = [
+    re.compile(r'(?i)\bwhere\s+(?:do|should|would|can)\s+i\s+(?:start|begin|learn)'),
+    re.compile(r'(?i)\bhow\s+(?:do|should|can)\s+i\s+(?:get\s+(?:started|into)|start|learn|begin)'),
+    re.compile(r'(?i)\bwhat\s+(?:should|do)\s+i\s+(?:learn|study|read|start\s+with)'),
+    re.compile(r'(?i)\b(?:any|got|have)\s+(?:good\s+)?'
+               r'(?:resources?|recommendations?|recs|tutorials?|courses?|guides?|books?|'
+               r'material|reading)\b'),
+    re.compile(r'(?i)\b(?:recommend|suggest)\s+(?:me\s+)?(?:a\s+|any\s+|some\s+)?'
+               r'(?:resources?|tutorials?|courses?|guides?|books?|reading|places?)\b'),
+    re.compile(r'(?i)\b(?:new|newbie|noob|beginner|just\s+joined|just\s+got\s+here)\b.{0,40}'
+               r'\b(?:start|begin|learn|advice|help|resources?)\b'),
+    re.compile(r'(?i)\b(?:best|good)\s+way\s+to\s+(?:learn|start|get\s+into)\b'),
+    re.compile(r'(?i)\bpoint\s+me\s+(?:to|at|in\s+the\s+right\s+direction)\b'),
+    re.compile(r'(?i)\bwhere\s+(?:can|do)\s+i\s+(?:find|look)\b.{0,30}'
+               r'\b(?:resources?|guides?|tutorials?|info|information)\b'),
+]
+
+# Asking about a specific technical problem is support, not orientation —
+# those deserve a human answer, not a signpost.
+_SPECIFIC_HELP = re.compile(
+    r'(?i)\b(?:error|exception|traceback|stack\s?trace|not\s+working|broken|'
+    r'fails?\s+to|why\s+(?:is|does|do)\s+my|my\s+\w+\s+(?:wont|won\'t|isn\'t|is\s+not))\b')
+
+_LLM_QUESTION = (
+    "You judge whether a Discord message is a NEWCOMER ASKING FOR DIRECTION "
+    "— where to start, what to learn, or which resources to use — as opposed "
+    "to anything else, including a specific technical support question, a "
+    "statement, a joke, or someone offering resources to others.\n"
+    "Respond in EXACTLY this format:\n"
+    "VERDICT: asking/not_asking/uncertain\n"
+    "REASON: <one short sentence>"
+)
+
+
+def _env(name: str, default: str = None) -> str:
+    """Env lookup that also consults the secrets manager for HELPER_* keys,
+    matching how MOD_* and AI_* keys are layered."""
+    value = os.getenv(name)
+    if value is None and name.startswith('HELPER_'):
+        from utils.secrets import get_secret
+        value = get_secret('HELPER', name[7:])
+    return value if value is not None else default
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = _env(name)
+    if value is None:
+        return default
+    return str(value).strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def _env_ids(name: str) -> set:
+    return {int(part) for part in re.findall(r'\d{5,}', _env(name, ''))}
+
+
+def looks_like_resource_request(content: str) -> bool:
+    """Deterministic first pass — cheap, and it runs on every message."""
+    if not content or _SPECIFIC_HELP.search(content):
+        return False
+    return any(pattern.search(content) for pattern in _ASK_PATTERNS)
+
+
+class NewcomerHelper(commands.Cog):
+    """Answers 'where do I start?' once, then stays quiet."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.enabled = _env_bool('HELPER_ENABLED', False)
+        self.channels = _env_ids('HELPER_CHANNELS')
+        self.tiers = {t.strip().lower() for t in _env('HELPER_TIERS', 'new').split(',')
+                      if t.strip()}
+        self.cooldown = float(_env('HELPER_COOLDOWN_SECONDS', '60'))
+        self.user_cooldown = float(_env('HELPER_USER_COOLDOWN_SECONDS', '1800'))
+        self.min_length = int(_env('HELPER_MIN_LENGTH', '12'))
+        self.use_llm = _env_bool('HELPER_USE_LLM', True)
+
+        resources = _env('HELPER_RESOURCE_CHANNEL_ID', '')
+        self.resource_channel_id = int(resources) if resources.isdigit() else None
+        rules = _env('HELPER_RULES_CHANNEL_ID', '')
+        self.rules_channel_id = int(rules) if rules.isdigit() else None
+        self.template = _env('HELPER_MESSAGE', DEFAULT_MESSAGE)
+
+        # Tier inputs are shared with moderation so one member is one tier.
+        self.member_days = int(_env('MOD_MEMBER_DAYS', '30'))
+        self.veteran_days = int(_env('MOD_VETERAN_DAYS', '365'))
+        self.trusted_roles = _env_ids('MOD_TRUSTED_ROLES')
+        self.creator_roles = _env_ids('MOD_CREATOR_ROLES')
+
+        self._channel_last = {}
+        self._user_last = {}
+        self._manager = None
+
+        if not self.enabled:
+            return
+        if not self.channels:
+            logger.error('HELPER_ENABLED=true but HELPER_CHANNELS is empty — '
+                         'the helper watches nothing until channels are allowlisted')
+            self.enabled = False
+        elif self.resource_channel_id is None:
+            logger.error('HELPER_ENABLED=true but HELPER_RESOURCE_CHANNEL_ID is '
+                         'not set — nothing to point at')
+            self.enabled = False
+
+    async def cog_load(self):
+        if self.enabled:
+            logger.info('Newcomer helper active: watching %d channel(s), tiers=%s, '
+                        'cooldown %.0fs/channel %.0fs/user',
+                        len(self.channels), ','.join(sorted(self.tiers)),
+                        self.cooldown, self.user_cooldown)
+
+    def _tier(self, member) -> str:
+        from utils.trust import trust_tier
+        return trust_tier(
+            member, member_days=self.member_days, veteran_days=self.veteran_days,
+            trusted_roles=self.trusted_roles, creator_roles=self.creator_roles,
+        )
+
+    def _mention(self, channel_id):
+        return f'<#{channel_id}>' if channel_id else None
+
+    def render(self, member) -> str:
+        """Fill the configured template. Missing channels degrade gracefully
+        rather than leaving a dangling '#None' in a welcome message."""
+        resources = self._mention(self.resource_channel_id) or 'the resources channel'
+        rules = self._mention(self.rules_channel_id)
+        rules_clause = f'Please have a look at {rules}, and ' if rules else ''
+        user = getattr(member, 'mention', None) or getattr(member, 'display_name', 'there')
+        try:
+            return self.template.format(
+                user=user, resources=resources, rules=rules or '',
+                rules_clause=rules_clause,
+            )
+        except (KeyError, IndexError):
+            # An operator's template referencing an unknown placeholder must
+            # not silence the feature — fall back to the shipped wording.
+            logger.warning('HELPER_MESSAGE has an unknown placeholder; using the default')
+            return DEFAULT_MESSAGE.format(
+                user=user, resources=resources, rules=rules or '',
+                rules_clause=rules_clause,
+            )
+
+    def _cooling_down(self, message, now: float) -> bool:
+        last_channel = self._channel_last.get(message.channel.id, 0)
+        if now - last_channel < self.cooldown:
+            return True
+        last_user = self._user_last.get(message.author.id, 0)
+        return now - last_user < self.user_cooldown
+
+    async def _confirms(self, content: str, username: str) -> bool:
+        """Second-stage veto for a borderline match.
+
+        Returns True when the model agrees or cannot be reached — the
+        deterministic pattern already matched, and a downed model should not
+        turn the feature off silently.
+        """
+        if not self.use_llm:
+            return True
+        try:
+            if self._manager is None:
+                from ai.manager import get_ai_manager
+                self._manager = await get_ai_manager()
+            from ai.features.moderation import ModerationAnalyzer
+            analyzer = ModerationAnalyzer(self._manager)
+            verdict = await analyzer.adjudicate_custom(
+                _LLM_QUESTION, content, username,
+                allowed={'asking', 'not_asking', 'uncertain'},
+            )
+            return verdict != 'not_asking'
+        except Exception:
+            logger.debug('Helper LLM check unavailable; keeping the regex match')
+            return True
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if not self.enabled or message.author.bot or not message.guild:
+            return
+        if message.channel.id not in self.channels:
+            return
+        content = (message.content or '').strip()
+        if len(content) < self.min_length:
+            return
+        if self._tier(message.author) not in self.tiers:
+            return
+        if not looks_like_resource_request(content):
+            return
+
+        now = time.monotonic()
+        if self._cooling_down(message, now):
+            logger.debug('Helper suppressed by cooldown in #%s',
+                         getattr(message.channel, 'name', message.channel.id))
+            return
+        if not await self._confirms(content, message.author.display_name):
+            return
+
+        try:
+            await message.reply(
+                self.render(message.author),
+                mention_author=False,
+                allowed_mentions=discord.AllowedMentions(
+                    everyone=False, roles=False, users=[message.author]),
+            )
+        except discord.HTTPException:
+            logger.exception('Could not send the newcomer pointer')
+            return
+
+        self._channel_last[message.channel.id] = now
+        self._user_last[message.author.id] = now
+        metrics.HELPER_REPLIES.inc()
+        logger.info('Pointed %s at the resources channel', message.author)
+
+
+async def setup(bot):
+    await bot.add_cog(NewcomerHelper(bot))
+    logger.info('NewcomerHelper cog loaded')

--- a/penguin-overlord/utils/metrics.py
+++ b/penguin-overlord/utils/metrics.py
@@ -58,11 +58,12 @@ if METRICS_ENABLED and PROMETHEUS_AVAILABLE:
     MOD_VERDICTS = Counter('penguin_mod_verdicts_total', 'Moderator labels on alerts', ['verdict'])
     MOD_ADJUDICATIONS = Counter('penguin_mod_adjudications_total', 'Context adjudications by the second-stage model', ['kind', 'outcome'])
     MOD_ATTACK_MARKERS = Counter('penguin_mod_attack_markers_total', 'Prompt-injection and filter-evasion techniques seen in scanned messages', ['marker'])
+    HELPER_REPLIES = Counter('penguin_helper_replies_total', 'Newcomer resource pointers sent')
 else:
     BOT_CONNECTED = GATEWAY_LATENCY = GUILD_COUNT = _NoopMetric()
     AI_REQUESTS = AI_LATENCY = AI_QUEUE_DROPPED = _NoopMetric()
     MOD_SCANS = MOD_ALERTS = MOD_ACTIONS = MOD_VERDICTS = MOD_ADJUDICATIONS = _NoopMetric()
-    MOD_ATTACK_MARKERS = _NoopMetric()
+    MOD_ATTACK_MARKERS = HELPER_REPLIES = _NoopMetric()
 
 
 _server_started = False

--- a/penguin-overlord/utils/trust.py
+++ b/penguin-overlord/utils/trust.py
@@ -1,0 +1,44 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""How long someone has been here, and what that earns them.
+
+Moderation uses tiers to decide who gets a context check instead of an
+automatic flag; the newcomer helper uses them to decide who gets a friendly
+pointer to the resources channel. Two features asking the same question
+deserve one answer, so this lives here rather than in either cog.
+
+    new      -> joined within MEMBER_DAYS (default 30)
+    member   -> past MEMBER_DAYS
+    veteran  -> past VETERAN_DAYS (default 365)
+    trusted  -> holds a configured staff role, whatever their tenure
+    creator  -> holds a configured creator role (outranks trusted)
+
+An unknown join date reads as `new`: the strict answer for moderation, and
+a harmless one for a welcome message.
+"""
+
+import discord
+
+TIERS = ('new', 'member', 'veteran', 'trusted', 'creator')
+
+
+def trust_tier(member, *, member_days: int = 30, veteran_days: int = 365,
+               trusted_roles=frozenset(), creator_roles=frozenset()) -> str:
+    """Tier for a guild member. Roles outrank tenure; creator outranks trusted."""
+    role_ids = {r.id for r in getattr(member, 'roles', [])}
+    if role_ids & set(creator_roles):
+        return 'creator'
+    if role_ids & set(trusted_roles):
+        return 'trusted'
+
+    joined = getattr(member, 'joined_at', None)
+    if joined is None:
+        return 'new'
+    days = (discord.utils.utcnow() - joined).days
+    if days >= veteran_days:
+        return 'veteran'
+    if days >= member_days:
+        return 'member'
+    return 'new'

--- a/tests/unit/test_ai_moderation_cog.py
+++ b/tests/unit/test_ai_moderation_cog.py
@@ -829,3 +829,18 @@ async def test_hate_speech_is_not_relaxed_by_the_technical_profile(cyber_cog):
     cyber_cog.analyzer = RecordingAnalyzer(DENYLIST_HIT)
     detections = await run_scan(cyber_cog, tenured_message(2))
     assert len(detections) == 1
+
+
+async def test_scan_cooldown_does_not_suppress_after_a_reboot(tier_cog, monkeypatch):
+    # Same defect as the helper's: time.monotonic() counts from boot, so a 0
+    # default made every user look recently-scanned for the first
+    # MOD_USER_COOLDOWN_SECONDS after the host came up.
+    import cogs.ai_moderation as module
+    monkeypatch.setattr(module.time, 'monotonic', lambda: 2.0)
+
+    tier_cog.analyzer = RecordingAnalyzer(
+        ModerationResult(False, 'harassment', 0.9, 'x', 'review'))
+    detections = await run_scan(tier_cog, tenured_message(
+        400, content='a perfectly ordinary message of sufficient length'))
+    assert tier_cog.analyzer.calls, 'the LLM scan was skipped by a phantom cooldown'
+    assert len(detections) == 1

--- a/tests/unit/test_newcomer_helper.py
+++ b/tests/unit/test_newcomer_helper.py
@@ -1,0 +1,211 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the newcomer helper.
+
+A bot that replies to things that were not questions is worse than one that
+stays quiet, so most of these are about NOT speaking.
+"""
+
+import types
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from cogs.newcomer_helper import NewcomerHelper, looks_like_resource_request
+
+WATCHED = 1016382144882409594
+RESOURCES = 1543285278381449288
+RULES = 1543285278381449289
+TRUSTED_ROLE = 1018625656055136347
+
+
+@pytest.fixture
+def helper(monkeypatch):
+    monkeypatch.setenv('HELPER_ENABLED', 'true')
+    monkeypatch.setenv('HELPER_CHANNELS', str(WATCHED))
+    monkeypatch.setenv('HELPER_RESOURCE_CHANNEL_ID', str(RESOURCES))
+    monkeypatch.setenv('HELPER_RULES_CHANNEL_ID', str(RULES))
+    monkeypatch.setenv('HELPER_USE_LLM', 'false')
+    monkeypatch.setenv('MOD_TRUSTED_ROLES', str(TRUSTED_ROLE))
+    monkeypatch.delenv('HELPER_MESSAGE', raising=False)
+    return NewcomerHelper(bot=types.SimpleNamespace())
+
+
+def make_message(content, *, days=1, channel_id=WATCHED, bot=False, roles=()):
+    replies = []
+
+    async def reply(text, **kw):
+        replies.append((text, kw))
+
+    author = types.SimpleNamespace(
+        id=111, bot=bot, display_name='newbie', mention='<@111>',
+        joined_at=datetime.now(timezone.utc) - timedelta(days=days),
+        roles=[types.SimpleNamespace(id=r) for r in roles],
+    )
+    author.__str__ = lambda self: 'newbie#0'
+    message = types.SimpleNamespace(
+        content=content, author=author,
+        channel=types.SimpleNamespace(id=channel_id, name='general'),
+        guild=types.SimpleNamespace(id=42), reply=reply,
+    )
+    message.replies = replies
+    return message
+
+
+# -- the pattern layer -------------------------------------------------------
+
+def test_recognises_asking_for_direction():
+    for text in (
+        'hey where do i start with all this?',
+        'How do I get into cybersecurity as a total beginner',
+        'what should i learn first, coming from sysadmin work',
+        'any good resources for someone new here?',
+        'can anyone recommend some courses on this stuff',
+        'just joined, any advice on where to begin?',
+        'whats the best way to learn pentesting',
+        'could someone point me in the right direction',
+        'where can i find guides for this',
+    ):
+        assert looks_like_resource_request(text), text
+
+
+def test_ignores_everything_that_is_not_a_request():
+    for text in (
+        'i learned that the hard way yesterday lol',
+        'here are some resources i put together for you all',
+        'this course was terrible honestly',
+        'starting my new job on monday',
+        'the book i keep on my desk is great',
+        'anyone else watching the stream tonight',
+        'i started using arch btw',
+    ):
+        assert not looks_like_resource_request(text), text
+
+
+def test_specific_support_questions_are_not_orientation():
+    # These want a human with an answer, not a signpost to the pinned channel.
+    for text in (
+        'any resources on why my nmap scan fails to resolve hostnames?',
+        'got a traceback when i run the tool, any guides for that error',
+        'my container wont start, any tutorials on debugging this',
+    ):
+        assert not looks_like_resource_request(text), text
+
+
+# -- the cog -----------------------------------------------------------------
+
+async def test_new_member_asking_gets_pointed(helper):
+    message = make_message('where do i start with cybersecurity?', days=1)
+    await helper.on_message(message)
+
+    assert len(message.replies) == 1
+    text, kwargs = message.replies[0]
+    assert f'<#{RESOURCES}>' in text
+    assert f'<#{RULES}>' in text
+    assert 'Welcome' in text
+    # never pings the room, and does not force a reply-ping either
+    assert kwargs['mention_author'] is False
+    assert kwargs['allowed_mentions'].everyone is False
+
+
+async def test_established_member_is_left_alone(helper):
+    # Default HELPER_TIERS=new: a two-year regular asking is just chat.
+    message = make_message('where do i start with rust?', days=800)
+    await helper.on_message(message)
+    assert message.replies == []
+
+
+async def test_channel_cooldown_stops_chatter(helper):
+    first = make_message('where do i start?')
+    await helper.on_message(first)
+    assert len(first.replies) == 1
+
+    second = make_message('any resources for beginners?')
+    second.author.id = 222          # different person, same channel
+    await helper.on_message(second)
+    assert second.replies == []
+
+
+async def test_user_cooldown_outlasts_the_channel_one(helper):
+    helper.cooldown = 0             # channel is free again immediately
+    first = make_message('where do i start?')
+    await helper.on_message(first)
+    assert len(first.replies) == 1
+
+    again = make_message('any tutorials someone can recommend?')
+    await helper.on_message(again)   # same author id
+    assert again.replies == []
+
+
+async def test_unwatched_channels_and_bots_are_ignored(helper):
+    elsewhere = make_message('where do i start?', channel_id=999999999)
+    await helper.on_message(elsewhere)
+    assert elsewhere.replies == []
+
+    robot = make_message('where do i start?', bot=True)
+    await helper.on_message(robot)
+    assert robot.replies == []
+
+
+async def test_short_messages_are_ignored(helper):
+    message = make_message('resources?')
+    await helper.on_message(message)
+    assert message.replies == []
+
+
+async def test_disabled_without_a_resource_channel(monkeypatch):
+    monkeypatch.setenv('HELPER_ENABLED', 'true')
+    monkeypatch.setenv('HELPER_CHANNELS', str(WATCHED))
+    monkeypatch.delenv('HELPER_RESOURCE_CHANNEL_ID', raising=False)
+    cog = NewcomerHelper(bot=types.SimpleNamespace())
+    assert cog.enabled is False
+
+
+async def test_disabled_without_an_allowlist(monkeypatch):
+    monkeypatch.setenv('HELPER_ENABLED', 'true')
+    monkeypatch.delenv('HELPER_CHANNELS', raising=False)
+    monkeypatch.setenv('HELPER_RESOURCE_CHANNEL_ID', str(RESOURCES))
+    cog = NewcomerHelper(bot=types.SimpleNamespace())
+    assert cog.enabled is False
+
+
+# -- message template --------------------------------------------------------
+
+def test_custom_template_is_used(monkeypatch, helper):
+    helper.template = 'yo {user}, try {resources}'
+    message = make_message('where do i start?')
+    assert helper.render(message.author) == f'yo <@111>, try <#{RESOURCES}>'
+
+
+def test_template_without_a_rules_channel_reads_cleanly(helper):
+    helper.rules_channel_id = None
+    text = helper.render(make_message('x').author)
+    assert 'None' not in text and '<#' in text
+
+
+def test_bad_placeholder_falls_back_instead_of_going_silent(helper):
+    helper.template = 'hello {nonexistent}'
+    text = helper.render(make_message('x').author)
+    assert f'<#{RESOURCES}>' in text
+
+
+async def test_llm_veto_is_respected(helper):
+    helper.use_llm = True
+
+    async def veto(content, username):
+        return False
+    helper._confirms = veto
+
+    message = make_message('where do i start with this?')
+    await helper.on_message(message)
+    assert message.replies == []
+
+
+async def test_llm_failure_keeps_the_regex_match(helper):
+    # A downed second model must not silently disable the feature.
+    helper.use_llm = True
+    message = make_message('where do i start with this?')
+    await helper.on_message(message)
+    assert len(message.replies) == 1

--- a/tests/unit/test_newcomer_helper.py
+++ b/tests/unit/test_newcomer_helper.py
@@ -209,3 +209,15 @@ async def test_llm_failure_keeps_the_regex_match(helper):
     message = make_message('where do i start with this?')
     await helper.on_message(message)
     assert len(message.replies) == 1
+
+
+async def test_cooldowns_do_not_suppress_on_a_freshly_booted_host(helper, monkeypatch):
+    # time.monotonic() counts from boot. With a 0 default, `now - 0` is below
+    # the cooldown on a machine that started seconds ago — so the helper went
+    # mute for its first minute of life. CI on a fresh runner caught this.
+    import cogs.newcomer_helper as module
+    monkeypatch.setattr(module.time, 'monotonic', lambda: 3.0)
+
+    message = make_message('where do i start with cybersecurity?')
+    await helper.on_message(message)
+    assert len(message.replies) == 1


### PR DESCRIPTION
"Where do I start with this?" gets asked constantly in a learning-oriented
server, usually by someone who has not found the pinned channels yet. This
answers once, politely, and gets out of the way.

## Silence is the default

The governing constraint is moderation's: **a false positive is expensive**. A
bot that replies to things that were not questions is worse than one that
stays quiet, because members learn to tune it out. Five gates:

1. **Tier** — `HELPER_TIERS` (default `new`). A two-year regular asking where
   to start is just conversation.
2. **Pattern** — a deterministic regex for a request for *direction*.
   Containing "learn" or "resources" is not enough: *"i learned that the hard
   way"* and *"here are some resources i put together for you all"* do not
   match.
3. **Not a support question** — *"any resources on why my nmap scan fails"*
   wants a human with an answer, not a signpost.
4. **Cooldowns** — per-channel (60s, configurable) so the bot never chatters,
   per-person (30m, configurable) so nobody gets followed around.
5. **Model veto** (optional) on borderline matches. When the model is
   unavailable the regex match stands: a downed model must not silently
   switch the feature off.

Only gates 4–5 cost anything beyond a regex, and 5 only runs on messages that
already matched.

## Configuration

```env
HELPER_ENABLED=true
HELPER_CHANNELS=123,456              # REQUIRED allowlist
HELPER_RESOURCE_CHANNEL_ID=789       # REQUIRED
HELPER_RULES_CHANNEL_ID=012          # optional
HELPER_COOLDOWN_SECONDS=60
HELPER_USER_COOLDOWN_SECONDS=1800
HELPER_MESSAGE=Welcome {user}! Please read {rules} and start with {resources}.
```

Enabled without an allowlist or a resource channel, the cog logs an error and
disables itself rather than guessing. A template naming an unknown placeholder
falls back to the default wording instead of going silent.

## Verified live, 6/6

| Message | Result |
|---|---|
| `where do i start with cybersecurity? just joined` | reply ✅ |
| `any good resources for learning malware analysis?` | reply ✅ |
| `could someone point me in the right direction here` | reply ✅ |
| `here are some resources i put together for you all` | quiet ✅ |
| `any resources on why my nmap scan fails to resolve` | quiet ✅ |
| `i started learning rust last year and it was great` | quiet ✅ |

## Along the way

- Trust tiers move to `utils/trust.py` — moderation and the helper were about
  to answer the same question two different ways.
- `ModerationAnalyzer.adjudicate_custom()` lets a feature outside moderation
  borrow the second-stage plumbing for one focused judgement.

## Also: MEE6 backlog note

`docs/features/ROLE_MANAGEMENT_NOTES.md` captures the role/levelling question
— what taking it over would need, why it might not be worth it (role
management is *destructive*, and XP migration may not be cleanly possible),
and a **reconciliation-only first step**: have the bot report what MEE6 should
have done and did not, touching nothing, so the real size of the gaps is
measured before anyone owns the feature. Mirrors how moderation was introduced
here. Notes only — nothing scheduled.

368 unit tests pass (17 new); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)