### PR TITLE
docs: bring the README, quick reference, and indexes up to the shipped features

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -59,10 +59,16 @@ All commands work with `!` prefix or as `/` slash commands!
 ### AI Moderation (opt-in, dry-run by default)
 | Command | Description |
 |---------|-------------|
-| `/mod status` | Show AI moderation status |
-| `/mod stats` | Per-category precision from moderator ✅/❌ labels |
+| `/mod status` | Moderation status: mode, profile, inference providers (no addresses) |
+| `/mod stats` | Per-category precision from moderator labels |
+| `/mod pending` | Open reviews nobody has decided, with jump links |
+| `/mod benchmark` | Accuracy against the built-in golden test set |
 | `/mod test text:...` | Run the analyzer on sample text (nothing is stored) |
 | `/mod purge_user` | Delete all stored moderation data for a user |
+
+On each alert: **Approve** / **Dismiss (false positive)** buttons, a
+**category select** to confirm under a corrected label, and ✅/❌ reactions
+on button-less alerts. `MOD_REVIEW_VOTES=2+` makes clicks votes.
 
 Requires `AI_ENABLED` + `AI_MODERATION_ENABLED` + `MOD_*` config — see
 [docs/features/AI_MODERATION.md](docs/features/AI_MODERATION.md).

--- a/README.md
+++ b/README.md
@@ -137,22 +137,47 @@ by default** and the bot behaves exactly as before until you opt in.
 - **AI Arch roasts** — contextual, guardrailed roasts when someone mentions
   Arch (btw); the static joke list remains the fallback for every failed or
   blocked generation
-- **Alert-first AI moderation** — regex PII/slur scanning plus LLM
-  classification (Llama Guard's native verdict protocol and instruction-template
-  models both supported); posts alert embeds with ✅/❌ calibration buttons to a
-  private mod channel, optionally @mentioning your moderator role. Dry-run by
-  default: no automatic actions, ever, until you graduate it
-- **Privacy floor** — moderation inference never leaves your network; the
-  remote (Gemini) fallback is hard-disabled for moderation in code
-- **Prometheus metrics** — `METRICS_ENABLED=true` exposes gateway, AI, and
-  moderation series plus a real container healthcheck
+- **Two-stage alert-first moderation** — regex PII/slur/dog-whistle scanning,
+  a Llama Guard primary verdict, and a context-capable second model for the
+  judgement calls: reclaimed in-group language vs. an attack, public vs.
+  private addresses, coded hate signals vs. ham radio's "73 and 88", and
+  educational security talk vs. targeting a real person. Edited messages are
+  rescanned. Dry-run by default: no automatic actions, ever, until you
+  graduate it
+- **Community profiles** — `MOD_PROFILE=cybersecurity,hobbyist` tells the
+  model what counts as normal talk in *your* server (IPs and exploit
+  discussion; locksport, radio, lawful firearms) and profiles compose. No
+  profile can relax hate speech, harassment, self-harm, or sexual content —
+  that floor is clamped in code
+- **Trust tiers** — new → member → veteran by tenure, trusted/creator by
+  role, shared across features; alerts show the tier so mods can weigh a
+  2-year regular differently from a 2-day-old account
+- **Attack labeling** — prompt-injection and filter-evasion attempts
+  (zero-width characters, homoglyphs, "ignore all previous instructions")
+  are named on the alert and flagged as `prompt_injection` even when they
+  carry no slur or PII
+- **Moderator calibration workflow** — alerts carry Approve / Dismiss
+  controls plus a category select for relabeling a true positive that was
+  tagged wrong; `MOD_REVIEW_VOTES=2+` turns clicks into votes with a live
+  tally. Every label feeds `/mod stats` and the future fine-tune
+- **Newcomer helper** — optionally points brand-new members at your rules
+  and resources channels when they ask where to start, with cooldowns and
+  a false-positive-averse matcher ([guide](docs/features/NEWCOMER_HELPER.md))
+- **Privacy floor** — moderation inference never leaves your network (the
+  remote fallback is hard-disabled for moderation in code), and nothing the
+  bot posts to Discord ever contains an endpoint address: private hosts
+  read `RFC1918`, public IPs are withheld, known APIs are named
+- **Prometheus metrics** — `METRICS_ENABLED=true` exposes gateway, AI,
+  moderation, adjudication, and attack-marker series plus a real container
+  healthcheck
 
-**Commands:** `/mod status`, `/mod stats`, `/mod test`, `/mod purge_user`
+**Commands:** `/mod status`, `/mod stats`, `/mod pending`, `/mod benchmark`,
+`/mod test`, `/mod purge_user`
 
 Per-feature models and hosts are configurable (e.g. roasting on
-`gemma3:12b`, moderation on `llama-guard3:8b`). See the
-[AI features operator guide](docs/features/AI_MODERATION.md) for setup,
-guardrails, and the calibration workflow.
+`gemma4:12b`, moderation on `llama-guard3:8b` + `gemma4:12b` second stage).
+See the [AI features operator guide](docs/features/AI_MODERATION.md) for
+setup, guardrails, and the calibration workflow.
 
 ### 📰 Automated News Aggregation (120+ sources, 11 categories)
 
@@ -499,7 +524,8 @@ safety check
 - ✅ **Docker multi-arch support** (amd64, arm64) with improved permission handling
 - ✅ **CI/CD with GitHub Actions**
 - ✅ **systemd service support** with timers and user-based installation
-- ✅ **AI subsystem (Ollama-first)** — Arch roasts + alert-first AI moderation with human calibration, hard guardrails, and per-feature models
+- ✅ **AI subsystem (Ollama-first)** — Arch roasts + two-stage alert-first moderation: trust tiers, community profiles, dog-whistle watchlist, attack labeling, moderator voting/relabeling, hard guardrails, per-feature models
+- ✅ **Newcomer helper** — configurable welcome pointer to rules/resources with cooldowns
 - ✅ **Prometheus metrics** endpoint with a real gateway healthcheck
 
 ### Future Features

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@
 - **[Secrets Management](secrets/README.md)** - Configure credentials securely
 
 ### ✨ Features
-- **[AI Features](features/AI_MODERATION.md)** - Ollama-backed Arch roasts and alert-first AI moderation
+- **[AI Features](features/AI_MODERATION.md)** - Arch roasts and two-stage alert-first moderation: trust tiers, community profiles, dog-whistle watchlist, moderator voting and relabeling
 - **[Newcomer Helper](features/NEWCOMER_HELPER.md)** - points new members at your resources channel
 - **[Role Management Notes](features/ROLE_MANAGEMENT_NOTES.md)** - future work: what taking over from MEE6 would involve
 - **[News System](features/NEWS_SYSTEM.md)** - 92 sources across 8 categories
@@ -197,7 +197,7 @@ Want to improve the documentation?
 3. Make your changes
 4. Submit a pull request
 
-See our [contributing guidelines](../CONTRIBUTING.md) for more details.
+See the [contributing section of the README](../README.md#-contributing) for more details.
 
 ---
 

--- a/penguin-overlord/cogs/ai_moderation.py
+++ b/penguin-overlord/cogs/ai_moderation.py
@@ -31,6 +31,14 @@ Configuration (env / secrets):
                                  PII/slur scans still run on everything)
     MOD_USER_COOLDOWN_SECONDS=20 per-user LLM-scan cooldown
     MOD_RETENTION_DAYS=90        stored excerpts are purged after this
+    MOD_PROFILE=general          community profile(s), comma-combinable
+                                 (general/cybersecurity/hobbyist) — see
+                                 ai/features/profiles.py
+    MOD_REVIEW_VOTES=1           moderators required to agree before a
+                                 review resolves (2+ turns clicks into votes)
+    MOD_LENIENCY_MAX_CONFIDENCE=0.95
+                                 above this, a context check may not clear a
+                                 model verdict (deny-list hits exempt)
 
     Trust tiers (new -> member -> veteran by tenure; trusted/creator by role):
     MOD_MEMBER_DAYS=30           tenure for the 'member' tier


### PR DESCRIPTION
The operator guide (`docs/features/AI_MODERATION.md`) kept pace with the last
week of moderation work, but the surfaces people actually land on did not: the
README's AI section still described a single-model, buttons-only system, and
the quick reference listed four `/mod` commands out of six with no mention of
the alert controls.

## Updated

**README AI section** — now describes what actually ships:
- two-stage moderation with the context adjudications (reclaimed in-group
  language, public vs. private addresses, dog whistles vs. ham radio's
  "73 and 88", educational security talk vs. targeting)
- community profiles (`MOD_PROFILE`, composable, protected floor stated
  plainly)
- trust tiers, edit rescanning, attack labeling / `prompt_injection`
- the calibration workflow: Approve / Dismiss, the **category select** for
  relabeling, `MOD_REVIEW_VOTES`, `/mod pending`, `/mod benchmark`
- the newcomer helper, linked from the feature list
- the endpoint-redaction privacy line (`RFC1918` / withheld / named APIs)

**QUICK_REFERENCE.md** — all six `/mod` commands plus the alert controls.

**Roadmap + docs index** — completed-features list and the index description
match reality; newcomer helper added as shipped.

**Cog docstring** — the env table gains `MOD_PROFILE`, `MOD_REVIEW_VOTES`,
`MOD_LENIENCY_MAX_CONFIDENCE`.

**Fixed along the way** — `docs/README.md` linked `../CONTRIBUTING.md`, which
does not exist; every local link in the touched docs now verified to resolve.

Docs only — no code changes; 380 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)