### PR TITLE
fix: feed follow-ups from the first live fetch cycle

### DIFF
--- a/penguin-overlord/cogs/vendor_alerts.py
+++ b/penguin-overlord/cogs/vendor_alerts.py
@@ -491,8 +491,13 @@ class VendorAlerts(commands.Cog):
                         date_str = item.get('date', '')
                         try:
                             parsed_date = date_parser.parse(date_str) if date_str else datetime.min.replace(tzinfo=timezone.utc)
-                        except:
+                        except Exception:
                             parsed_date = datetime.min.replace(tzinfo=timezone.utc)
+                        # Feeds disagree about carrying a timezone; a batch
+                        # mixing naive and aware datetimes cannot be sorted
+                        # (the AWS status feed exposed this). Naive == UTC.
+                        if parsed_date.tzinfo is None:
+                            parsed_date = parsed_date.replace(tzinfo=timezone.utc)
                         
                         all_new_items.append({
                             'item': item,

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,3 +36,7 @@ ollama==0.6.1
 
 # Prometheus metrics endpoint for Grafana (opt-in via METRICS_ENABLED=true)
 prometheus-client==0.21.1
+
+# Feed CDNs (TheCyberWire, Cyber Express, Cisco) serve brotli-compressed
+# responses; without this aiohttp cannot decode them (400 content-encoding)
+Brotli>=1.2.0


### PR DESCRIPTION
Two things the deploy's first fetch cycle surfaced:

1. **vendor_alerts crashed sorting its batch** — `date_parser` returns naive
   datetimes for feeds without timezone info and aware ones for feeds with
   them; a mixed batch cannot be sorted. Latent until the new AWS status feed
   (which carries timezones) joined the mix. Naive now reads as UTC.

2. **The last three fetch errors shared one cause**: TheCyberWire, Cyber
   Express, and Cisco's CDNs serve brotli-compressed responses, and the
   `Brotli` package wasn't installed — aiohttp failed with
   `Can not decode content-encoding: brotli`. One dependency fixes all three
   (and quiets urllib3's decompression-bomb warning in tests).

Expected result: **zero feed errors per fetch cycle**, down from ten two days
ago. 394 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)