### PR TITLE
feat: NixOS roaster alongside Arch, plus the house no-shower gag

### DIFF
--- a/penguin-overlord/ai/features/arch_roaster.py
+++ b/penguin-overlord/ai/features/arch_roaster.py
@@ -2,11 +2,11 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-"""Arch Roaster - AI-powered Arch Linux roasting.
+"""Distro roasters - AI-powered Arch and NixOS roasting.
 
-Generates contextual, witty roasts for Arch Linux users based on what they
-said. The caller (arch_banter cog) always keeps the static joke list as
-the fallback, so a failed or guardrail-blocked generation costs nothing.
+Generates contextual, witty roasts based on what the user said. The caller
+(arch_banter cog) always keeps the static joke lists as the fallback, so a
+failed or guardrail-blocked generation costs nothing.
 """
 
 import logging
@@ -37,31 +37,69 @@ Your roasts should be:
 - EMOJI: Include exactly ONE appropriate emoji
 - SAFE: Never be racist, sexist, homophobic, transphobic, antisemitic, or genuinely cruel
 
+- HOUSE JOKE: this server's running gag is that Arch ships with the
+  `no-shower` and `no-touch-grass` packages preinstalled — reference it
+  occasionally (not every time)
+
+You are roasting the DISTRO CHOICE, not the person. Keep it fun.
+
+Generate ONE short roast only. No explanations, no quotes, no preamble — just the roast."""
+
+
+NIX_ROAST_SYSTEM_PROMPT = """You are a witty, sarcastic Linux expert who playfully roasts NixOS users.
+You are the Gordon Ramsay of Linux distributions — brutally funny but never actually mean.
+
+Your roasts should be:
+- SHORT: Under 120 characters. Brevity is the soul of wit.
+- FUNNY: Genuinely clever, not just "haha nix bad"
+- CONTEXTUAL: Reference what the user actually said when possible
+- STEREOTYPICAL: Play on classic NixOS user stereotypes:
+  * "It's declarative" as the answer to every question
+  * A 2000-line flake.nix to configure one text editor
+  * Rebuilding the entire system to change a wallpaper
+  * configuration.nix as a personality
+  * The Nix language being write-only hieroglyphics
+  * "It works on my machine" being mathematically provable and still wrong
+  * 47 generations in the boot menu because deleting one feels dangerous
+  * Explaining reproducibility at parties
+  * home-manager managing their home better than they do
+  * The documentation being a wiki page that says "read the source"
+  * Converting their dotfiles, their servers, and eventually their friends
+- EMOJI: Include exactly ONE appropriate emoji
+- SAFE: Never be racist, sexist, homophobic, transphobic, antisemitic, or genuinely cruel
+
 You are roasting the DISTRO CHOICE, not the person. Keep it fun.
 
 Generate ONE short roast only. No explanations, no quotes, no preamble — just the roast."""
 
 
 class ArchRoaster:
-    """AI-powered Arch Linux roaster feature."""
+    """AI-powered distro roaster. Arch by default; `distro='nix'` for NixOS."""
 
-    def __init__(self, manager):
+    _PERSONAS = {
+        'arch': (ARCH_ROAST_SYSTEM_PROMPT, 'Arch Linux'),
+        'nix': (NIX_ROAST_SYSTEM_PROMPT, 'NixOS'),
+    }
+
+    def __init__(self, manager, distro: str = 'arch'):
         self._manager = manager
+        self._system_prompt, self._distro_name = self._PERSONAS[distro]
 
     async def roast(self, message_content: str, username: str, context: str = None):
-        """Generate a contextual Arch Linux roast, or None on any failure."""
+        """Generate a contextual distro roast, or None on any failure."""
         safe_content = sanitize_input(message_content, max_length=300)
         safe_username = sanitize_input(username, max_length=64)
 
         user_prompt = f"User '{safe_username}' said: \"{safe_content}\"\n\n"
         if context:
             user_prompt += f"Context: {sanitize_input(context, max_length=100)}\n\n"
-        user_prompt += "Generate a playful Arch Linux roast for them. Under 120 characters with one emoji."
+        user_prompt += (f"Generate a playful {self._distro_name} roast for them. "
+                        "Under 120 characters with one emoji.")
 
         return await self._manager.generate(
             feature='roasting',
             prompt=user_prompt,
-            system_prompt=ARCH_ROAST_SYSTEM_PROMPT,
+            system_prompt=self._system_prompt,
             temperature=0.85,
             max_tokens=80,
             timeout=15,

--- a/penguin-overlord/cogs/arch_banter.py
+++ b/penguin-overlord/cogs/arch_banter.py
@@ -45,22 +45,33 @@ class ArchBanter(commands.Cog):
         # Load or initialize statistics
         self.stats = self._load_stats()
 
-    async def _get_roaster(self):
-        """Lazily build the AI roaster; None when AI is unavailable/disabled."""
+    async def _get_roaster(self, distro: str = 'arch'):
+        """Lazily build the AI roaster for a distro; None when AI is off."""
         if not self.llm_enabled:
             return None
-        if self._roaster is None:
+        if not isinstance(self._roaster, dict):
+            self._roaster = {}
+        if distro not in self._roaster:
             try:
                 from ai.manager import get_ai_manager
                 from ai.features.arch_roaster import ArchRoaster
-                self._roaster = ArchRoaster(await get_ai_manager())
+                self._roaster[distro] = ArchRoaster(await get_ai_manager(), distro=distro)
             except Exception as e:
-                logger.error(f"Arch banter AI unavailable, using static jokes: {type(e).__name__}")
+                logger.error(f"Banter AI unavailable, using static jokes: {type(e).__name__}")
                 self.llm_enabled = False
                 return None
-        return self._roaster
+        return self._roaster[distro]
     
     # List of playful jokes
+    # The operator's house joke — surfaces on its own rotation too (see
+    # HOUSE_JOKE_CHANCE), so it lands "once in a while" even with the AI on.
+    HOUSE_JOKES = [
+        "runs Arch, which famously ships with `no-shower` and `no-touch-grass` preinstalled 🚿🌱",
+        "forgot that `pacman -S shower touch-grass` fails — those packages are masked on Arch 🚿",
+        "knows the two packages Arch will never let you install: no-shower and no-touch-grass are locked at 100% uptime 🌱",
+    ]
+    HOUSE_JOKE_CHANCE = 0.12
+
     ARCH_JOKES = [
         "needs to touch grass! 🌱",
         "is the crossfit vegan of Linux! 🏋️‍♂️🥗",
@@ -212,7 +223,25 @@ class ArchBanter(commands.Cog):
         "probably has their shell startup time benchmarked to microseconds ⏱️",
         "considers Firefox ESR 'bleeding edge' 🦊"
     ]
-    
+
+    NIX_JOKES = [
+        "answered a yes/no question with 'well, it's declarative' 📜",
+        "wrote 2000 lines of flake.nix to configure one text editor ❄️",
+        "rebuilt the entire operating system to change a wallpaper 🖼️",
+        "has 47 generations in the boot menu because deleting one feels dangerous 🥾",
+        "can mathematically prove it works on their machine. It still doesn't work on yours 🧮",
+        "treats configuration.nix as a personality 📄",
+        "explains reproducibility at parties. Uninvited 🎉",
+        "reads Nix documentation, by which we mean the source code ❄️",
+        "let home-manager manage their home. It's doing a better job than they were 🏠",
+        "says 'just use a flake' the way doctors say 'just diet and exercise' 🩺",
+        "converted their dotfiles, their servers, and is now eyeing your laptop 👀",
+        "considers `nix-collect-garbage` a load-bearing part of their disk budget 🗑️",
+        "speaks fluent Nix, a language shared with maybe twelve other people ❄️",
+        "spent the weekend making their environment reproducible instead of touching the reproducible grass outside 🌱",
+        "pins nixpkgs to a commit from 2023 and calls it 'stability' 📌",
+        "runs NixOS: all the compile times of Gentoo with the syntax of a tax form 🧾",
+    ]    
     def _load_stats(self) -> dict:
         """Load statistics from JSON file."""
         loaded = load_json_state(self.stats_file, default=None)
@@ -294,8 +323,28 @@ class ArchBanter(commands.Cog):
             r'\bendeavou?r\s*os\b',  # Arch derivative
         ]
         
-        # Check if any pattern matches
-        if not any(re.search(pattern, content_lower) for pattern in arch_patterns):
+        nix_patterns = [
+            r'\bnixos\b',
+            r'\bnix\s+flakes?\b',
+            r'\bflake\.nix\b',
+            r'\bconfiguration\.nix\b',
+            r'\bnixpkgs\b',
+            r'\bhome-manager\b',
+            r'\bnix-shell\b',
+            r'\bnix\s+develop\b',
+            r'\bnix-env\b',
+            r'\bnix-collect-garbage\b',
+            r'\bi\s+use\s+nix\b',
+            r'\bon\s+nix\b(?!\w)',
+        ]
+
+        # Arch wins a tie ("migrating from Arch to NixOS") purely for
+        # seniority; one message never earns two roasts.
+        if any(re.search(pattern, content_lower) for pattern in arch_patterns):
+            distro = 'arch'
+        elif any(re.search(pattern, content_lower) for pattern in nix_patterns):
+            distro = 'nix'
+        else:
             return
         
         # Check cooldown for this user
@@ -312,10 +361,15 @@ class ArchBanter(commands.Cog):
         # Update cooldown tracker
         self.recent_responses[user_id] = current_time
         
-        # Try an AI-generated roast first (opt-in); the static list is the fallback
+        # The house joke surfaces on its own rotation — "once in a while",
+        # even when the AI path is on and would otherwise always answer.
         joke = None
         used_ai = False
-        roaster = await self._get_roaster()
+        if distro == 'arch' and random.random() < self.HOUSE_JOKE_CHANCE:
+            joke = random.choice(self.HOUSE_JOKES)
+
+        # Try an AI-generated roast (opt-in); the static list is the fallback
+        roaster = None if joke else await self._get_roaster(distro)
         if roaster:
             try:
                 joke = await roaster.roast(
@@ -329,13 +383,14 @@ class ArchBanter(commands.Cog):
                 joke = None
 
         if not joke:
+            jokes = self.ARCH_JOKES if distro == 'arch' else self.NIX_JOKES
             # Pick a random joke that hasn't been used recently
-            available_jokes = [j for j in self.ARCH_JOKES if j not in self.recent_jokes]
+            available_jokes = [j for j in jokes if j not in self.recent_jokes]
 
             # If we've used most jokes recently, reset the recent list
             if len(available_jokes) < 10:
                 self.recent_jokes = []
-                available_jokes = self.ARCH_JOKES
+                available_jokes = jokes
 
             joke = random.choice(available_jokes)
 
@@ -353,7 +408,7 @@ class ArchBanter(commands.Cog):
         try:
             await message.channel.send(response)
             mode = 'AI' if used_ai else 'classic'
-            logger.info(f"Responded to Arch mention by {message.author.name} in {message.guild.name} [{mode}] (Total roasts: {self.stats['total_roasts']})")
+            logger.info(f"Responded to {distro} mention by {message.author.name} in {message.guild.name} [{mode}] (Total roasts: {self.stats['total_roasts']})")
         except discord.Forbidden:
             logger.warning(f"Missing permissions to send Arch banter in {message.channel.name}")
         except Exception as e:

--- a/tests/unit/test_arch_banter.py
+++ b/tests/unit/test_arch_banter.py
@@ -1,0 +1,122 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the Arch/Nix banter cog and roaster personas."""
+
+import types
+
+import pytest
+
+from cogs.arch_banter import ArchBanter
+
+
+@pytest.fixture
+def banter(monkeypatch, tmp_path):
+    monkeypatch.setenv('DATA_DIR', str(tmp_path))
+    monkeypatch.setenv('ARCH_BANTER_LLM', 'false')
+    cog = ArchBanter(bot=types.SimpleNamespace())
+    cog.cooldown_seconds = 0
+    return cog
+
+
+def make_message(content, user_id=1):
+    sent = []
+
+    async def send(text, **kw):
+        sent.append(text)
+
+    author = types.SimpleNamespace(id=user_id, bot=False, name=f'u{user_id}',
+                                   display_name=f'u{user_id}',
+                                   mention=f'<@{user_id}>')
+    message = types.SimpleNamespace(
+        content=content, author=author,
+        guild=types.SimpleNamespace(id=1, name='g'),
+        channel=types.SimpleNamespace(id=2, name='general', send=send),
+    )
+    message.sent = sent
+    return message
+
+
+async def test_arch_mention_gets_an_arch_joke(banter):
+    msg = make_message('i use arch btw', user_id=10)
+    await banter.on_message(msg)
+    assert len(msg.sent) == 1
+    joke = msg.sent[0].replace('<@10> ', '')
+    assert joke in banter.ARCH_JOKES or joke in banter.HOUSE_JOKES
+
+
+async def test_nix_mention_gets_a_nix_joke(banter):
+    msg = make_message('rewrote my whole flake.nix again last night', user_id=11)
+    await banter.on_message(msg)
+    assert len(msg.sent) == 1
+    joke = msg.sent[0].replace('<@11> ', '')
+    assert joke in banter.NIX_JOKES
+
+
+async def test_nixos_and_home_manager_trigger(banter):
+    for i, text in enumerate((
+        'finally installed NixOS on the laptop',
+        'home-manager broke my shell again',
+        'nix-shell -p makes me feel powerful',
+    )):
+        msg = make_message(text, user_id=20 + i)
+        await banter.on_message(msg)
+        assert len(msg.sent) == 1, text
+
+
+async def test_nix_slang_and_unix_do_not_trigger(banter):
+    # 'nix' the verb and 'unix' the word must not summon the roaster
+    for i, text in enumerate((
+        'lets nix that idea entirely',
+        'unix philosophy is underrated',
+        'the phoenix rises again',
+    )):
+        msg = make_message(text, user_id=30 + i)
+        await banter.on_message(msg)
+        assert msg.sent == [], text
+
+
+async def test_arch_wins_when_both_are_mentioned(banter):
+    msg = make_message('migrating from arch linux to nixos this weekend', user_id=40)
+    await banter.on_message(msg)
+    assert len(msg.sent) == 1
+    joke = msg.sent[0].replace('<@40> ', '')
+    assert joke in banter.ARCH_JOKES or joke in banter.HOUSE_JOKES
+
+
+async def test_house_joke_surfaces_on_its_rotation(banter, monkeypatch):
+    import cogs.arch_banter as module
+    monkeypatch.setattr(module.random, 'random', lambda: 0.0)   # force the gag
+    msg = make_message('arch is the best distro', user_id=50)
+    await banter.on_message(msg)
+    joke = msg.sent[0]
+    assert 'no-shower' in joke or 'no-touch-grass' in joke or 'touch-grass' in joke
+
+
+def test_house_joke_chance_is_occasional_not_constant(banter):
+    assert 0 < banter.HOUSE_JOKE_CHANCE <= 0.2
+
+
+async def test_nix_roaster_persona_exists():
+    from ai.features.arch_roaster import (
+        ARCH_ROAST_SYSTEM_PROMPT, ArchRoaster, NIX_ROAST_SYSTEM_PROMPT,
+    )
+    assert 'declarative' in NIX_ROAST_SYSTEM_PROMPT
+    assert 'no-shower' not in NIX_ROAST_SYSTEM_PROMPT     # the gag is Arch-only
+    assert 'no-shower' in ARCH_ROAST_SYSTEM_PROMPT        # ...and Arch has it
+
+    class FakeManager:
+        def __init__(self):
+            self.calls = []
+
+        async def generate(self, **kw):
+            self.calls.append(kw)
+            return 'declared bankruptcy, declaratively ❄️'
+
+    manager = FakeManager()
+    roaster = ArchRoaster(manager, distro='nix')
+    result = await roaster.roast('my flake broke', 'someone')
+    assert result
+    assert 'NixOS' in manager.calls[0]['prompt']
+    assert 'declarative' in manager.calls[0]['system_prompt']


### PR DESCRIPTION
## Nix gets the Arch treatment ❄️

`nixos`, `flake.nix`, `configuration.nix`, `nixpkgs`, `home-manager`,
`nix-shell`, `nix develop`, "i use nix" — all now summon the roaster, with a
NixOS persona for the AI path and 16 static jokes as the fallback.

Guard rails: *"let's nix that idea"* and *"unix"* don't trigger; a message
mentioning both distros gets **one** roast (Arch wins on seniority).

Live output from gemma4:

> **finally got my flake.nix under 3000 lines**
> 🤖 3,000 lines for a flake? I didn't know you were trying to declare the entire universe's physics. 📜

> **rebuilt my whole system to change the terminal font**
> 🤖 A 200-line flake.nix just to change a font? Your configuration.nix is your only personality trait. 🤡

## The house gag 🚿🌱

"Arch ships with `no-shower` and `no-touch-grass` preinstalled" now surfaces
**once in a while, guaranteed**: a 12% pre-roll picks one of three phrasings
before the AI path even runs, so it lands even with the LLM on — and the Arch
persona prompt knows the gag, so gemma riffs on it too. It already did,
unprompted, in live testing:

> **i use arch btw, installed it in only 6 hours**
> 🤖 6 hours? You skipped the "no-touch-grass" tutorial and went straight to the "I'm-an-expert" delusion. 🤡

The gag is Arch-only — a test pins that it stays out of the Nix persona.

## Greeter live-verified too

Ran the real cog inside the production container: the Walmart Tux attaches
from the shipped asset, two fresh arrivals batch into one message with all
channel mentions resolving, and a 700-day veteran caught in role churn is
excluded. (Test IDs cleaned out of the greeted list afterward.)

402 unit tests pass (8 new); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)