### PR TITLE
feat: Skid Detector — a joke alarm for script-kiddie energy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -84,6 +84,13 @@ DOPPLER_CONFIG=prd
 # the label follows the majority as they arrive.
 # MOD_REVIEW_VOTES=1
 
+# Optional: Skid Detector — a joke alarm that occasionally ribs messages
+# sounding like a script kiddie ("teach me to hack"). Comedy, not
+# moderation; nobody is exempt. On by default.
+# SKID_DETECTOR_ENABLED=true
+# SKID_FIRE_CHANCE=0.30              # chance a matching message triggers
+# SKID_COOLDOWN_SECONDS=180         # per-user quiet period
+
 # Optional: community profile(s) — what counts as normal talk in this server.
 # Combine with commas; every listed topic becomes on-topic. Profiles never
 # relax hate speech, harassment, self-harm, or sexual content.

--- a/penguin-overlord/cogs/skid_detector.py
+++ b/penguin-overlord/cogs/skid_detector.py
@@ -1,0 +1,149 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Skid Detector — a joke alarm that goes off when someone sounds like a
+script kiddie.
+
+This is comedy, NOT moderation. It never flags, logs, stores, or reports
+anything; it just occasionally posts a deadpan "threat readout" ribbing a
+message that pattern-matches classic skiddie energy ("teach me to hack",
+"is this illegal", "i downloaded kali"). Everyone is a valid victim —
+there is no trust exemption, and the operator gets caught by their own bot
+like anyone else, which is the whole joke.
+
+Two dials keep it from being annoying:
+- It only *considers* messages that trip a skiddie pattern.
+- Even then it fires with probability SKID_FIRE_CHANCE (default 0.30), so
+  it stays a surprise rather than a reflex, and a per-user cooldown means
+  nobody gets detector-bombed.
+
+Configuration:
+    SKID_DETECTOR_ENABLED=true    master switch (on by default — it's a gag)
+    SKID_FIRE_CHANCE=0.30         probability a matching message triggers
+    SKID_COOLDOWN_SECONDS=180     per-user quiet period
+"""
+
+import logging
+import os
+import random
+import re
+import time
+
+import discord
+from discord.ext import commands
+
+logger = logging.getLogger(__name__)
+
+# Phrases that radiate script-kiddie energy. Deliberately broad and a little
+# unfair — being occasionally wrong is funnier than being precise.
+_SKID_PATTERNS = [
+    r'\bteach me (?:how )?to hack\b',
+    r'\bhow (?:do i|to|can i) (?:hack|ddos|dox|crack|breach|pwn|boot|swat)\b',
+    r'\bhow (?:do i|to|can i) (?:get|become) (?:a )?hacker\b',
+    r'\bhack (?:my|his|her|their|this|that|the) (?:ex|gf|bf|friend|account|insta|snap|wifi|school)\b',
+    r'\b(?:give|send|got|need|want) (?:me )?(?:a )?(?:rat|botnet|stealer|logger|cheat|crypter|c2)\b',
+    r'\b(?:free )?(?:booter|stresser|ip puller|token logger|account cracker)\b',
+    r'\bis (?:this|it|that) (?:illegal|legal|a crime|traceable|untraceable)\b',
+    r'\bcan i (?:go to jail|get caught|get traced|get v& |get vand)\b',
+    r'\bi (?:just )?(?:downloaded|installed|got) kali\b',
+    r'\bi(?:\'?m| am) (?:basically )?(?:a )?(?:hacker|pentester|red ?team)\b(?!.*\bjob\b)',
+    r'\b(?:ip )?grab(?:bed|bing)? (?:his|her|their|your) ip\b',
+    r'\bboot(?:ed|ing)? (?:him|her|them|you) offline\b',
+    r'\bnigerian prince\b',
+    r'\bhow much (?:for|to) (?:hack|a hack|ddos)\b',
+    r'\b(?:sql ?inject|sqlmap|metasploit|hydra|aircrack|wireshark)\b.*\b(?:noob|newbie|how|help|easy)\b',
+    r'\bwhat(?:\'?s| is) the best (?:hacking|hacker) (?:app|tool|software)\b',
+    r'\bmr ?robot (?:taught|showed) me\b',
+    r'\bdeauth (?:the|my|his|her|their) (?:whole )?(?:school|neighborhood|street)\b',
+]
+_SKID_RE = re.compile('|'.join(_SKID_PATTERNS), re.IGNORECASE)
+
+# The gag output. Each is a deadpan mock "readout". {user} is the victim.
+_VERDICTS = [
+    "🚨 **SKID DETECTOR** 🚨\n{user}, our sensors detected **elite hacker energy**. "
+    "Threat level: *downloaded Kali once*. Recommended action: read a man page. 🧢",
+
+    "🚨 **SKID DETECTOR** 🚨\nAlert: {user} is radiating **1337 h4x0r** signals. "
+    "Confidence: 420%. Actual skill: `sudo apt install courage`. 💀",
+
+    "🚨 **SKID DETECTOR** 🚨\n{user} flagged for **advanced persistent skiddery**. "
+    "Origin IP: 127.0.0.1. Payload: pure vibes. Mitigation: touch keyboard, not grass. ⌨️",
+
+    "🚨 **SKID DETECTOR** 🚨\nSuspect {user} matched the profile: owns a hoodie, "
+    "runs `nmap localhost`, calls it a pentest. Sentence: 6 hours on the Arch wiki. 🥷",
+
+    "🚨 **SKID DETECTOR** 🚨\n{user}, your ports are showing. We ran a scan and found "
+    "**one (1) open Discord and a dream**. Please close both. 🔍",
+
+    "🚨 **SKID DETECTOR** 🚨\nIncoming threat: {user}. Weapon of choice: a YouTube "
+    "tutorial paused at 0:37. Countermeasure deployed: this message. 📼",
+
+    "🚨 **SKID DETECTOR** 🚨\n{user} has been identified as the hacker known as "
+    "**4chan**. Interpol notified. (Interpol said 'lol no'.) 🌐",
+
+    "🚨 **SKID DETECTOR** 🚨\nWARNING: {user} said the scary words. Our AI is 100% "
+    "sure they own a Guy Fawkes mask still in the Amazon box. 🎭",
+
+    "🚨 **SKID DETECTOR** 🚨\n{user} detected running **Mr. Robot: The Home Game**. "
+    "Skill ceiling: `rm -rf` a folder they'll regret. Please don't. 🤖",
+
+    "🚨 **SKID DETECTOR** 🚨\nThreat {user} neutralized. Turns out it was just someone "
+    "who found the green-on-black terminal theme. We've all been there. 💚",
+]
+
+
+def _env(name: str, default: str) -> str:
+    return os.getenv(name, default)
+
+
+def looks_like_skid(content: str) -> bool:
+    """True if a message trips a skiddie pattern. Cheap; runs on every message."""
+    return bool(content) and _SKID_RE.search(content) is not None
+
+
+class SkidDetector(commands.Cog):
+    """A joke alarm. No moderation, no logging of users — just bits."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.enabled = _env('SKID_DETECTOR_ENABLED', 'true').strip().lower() \
+            in ('1', 'true', 'yes', 'on')
+        self.fire_chance = float(_env('SKID_FIRE_CHANCE', '0.30'))
+        self.cooldown = float(_env('SKID_COOLDOWN_SECONDS', '180'))
+        self._last: dict = {}
+
+    @commands.Cog.listener()
+    async def on_message(self, message: discord.Message):
+        if not self.enabled or message.author.bot or not message.guild:
+            return
+        if not looks_like_skid(message.content):
+            return
+
+        # Random fire: a matching message is a candidate, not a guarantee —
+        # the surprise is the bit.
+        if random.random() >= self.fire_chance:
+            return
+
+        now = time.monotonic()
+        last = self._last.get(message.author.id)
+        if last is not None and now - last < self.cooldown:
+            return
+        self._last[message.author.id] = now
+        if len(self._last) > 5000:
+            self._last.clear()
+
+        verdict = random.choice(_VERDICTS).format(user=message.author.mention)
+        try:
+            await message.reply(
+                verdict, mention_author=False,
+                allowed_mentions=discord.AllowedMentions(
+                    everyone=False, roles=False, users=[message.author]),
+            )
+        except discord.HTTPException:
+            logger.debug('Skid detector could not reply (harmless)')
+
+
+async def setup(bot):
+    await bot.add_cog(SkidDetector(bot))
+    logger.info('SkidDetector cog loaded')

--- a/tests/unit/test_skid_detector.py
+++ b/tests/unit/test_skid_detector.py
@@ -1,0 +1,118 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for the Skid Detector gag cog.
+
+It is comedy, not moderation: these check it fires on the right vibe, that
+randomness and cooldown keep it from spamming, and that NOBODY is exempt.
+"""
+
+import types
+
+import pytest
+
+import cogs.skid_detector as module
+from cogs.skid_detector import SkidDetector, looks_like_skid
+
+
+@pytest.fixture
+def skid(monkeypatch):
+    monkeypatch.setenv('SKID_DETECTOR_ENABLED', 'true')
+    monkeypatch.setenv('SKID_FIRE_CHANCE', '1.0')      # deterministic in tests
+    monkeypatch.setenv('SKID_COOLDOWN_SECONDS', '180')
+    return SkidDetector(bot=types.SimpleNamespace())
+
+
+def make_message(content, user_id=1, bot=False):
+    replies = []
+
+    async def reply(text, **kw):
+        replies.append((text, kw))
+
+    author = types.SimpleNamespace(id=user_id, bot=bot, mention=f'<@{user_id}>')
+    message = types.SimpleNamespace(
+        content=content, author=author, reply=reply,
+        guild=types.SimpleNamespace(id=1),
+    )
+    message.replies = replies
+    return message
+
+
+def test_recognises_skid_energy():
+    for text in (
+        'teach me to hack my ex insta',
+        'how do i ddos someone',
+        'is this illegal btw',
+        'i just downloaded kali im basically a hacker now',
+        'can someone give me a rat',
+        'grabbed his ip lets boot him offline',
+        "what's the best hacking app",
+        'mr robot taught me everything',
+    ):
+        assert looks_like_skid(text), text
+
+
+def test_ordinary_talk_is_not_skid():
+    for text in (
+        'i work in incident response, wrote a detection today',
+        'the ddos mitigation held up fine during the drill',
+        'kali is a solid distro for pentesting engagements',
+        'anyone else watching the game tonight',
+        'i love my new keyboard',
+    ):
+        assert not looks_like_skid(text), text
+
+
+async def test_fires_on_a_match(skid):
+    msg = make_message('teach me to hack the school wifi', user_id=10)
+    await skid.on_message(msg)
+    assert len(msg.replies) == 1
+    text, kwargs = msg.replies[0]
+    assert 'SKID DETECTOR' in text
+    assert '<@10>' in text
+    assert kwargs['mention_author'] is False
+    assert kwargs['allowed_mentions'].everyone is False
+
+
+async def test_nobody_is_exempt(skid):
+    # No trust tiers, no owner bypass — everyone is a victim, that's the joke.
+    for uid in (10, 999, 205412430510030848):
+        msg = make_message('how do i become a hacker', user_id=uid)
+        await skid.on_message(msg)
+        assert len(msg.replies) == 1, uid
+
+
+async def test_randomness_can_hold_fire(monkeypatch):
+    monkeypatch.setenv('SKID_DETECTOR_ENABLED', 'true')
+    monkeypatch.setenv('SKID_FIRE_CHANCE', '0.30')
+    cog = SkidDetector(bot=types.SimpleNamespace())
+    monkeypatch.setattr(module.random, 'random', lambda: 0.99)   # above the bar
+    msg = make_message('teach me to hack', user_id=11)
+    await cog.on_message(msg)
+    assert msg.replies == []
+
+
+async def test_cooldown_prevents_detector_bombing(skid):
+    first = make_message('how do i ddos someone', user_id=12)
+    await skid.on_message(first)
+    assert len(first.replies) == 1
+    second = make_message('is this illegal', user_id=12)
+    await skid.on_message(second)
+    assert second.replies == []          # same user, still cooling down
+
+
+async def test_bots_and_non_matches_are_ignored(skid):
+    robot = make_message('teach me to hack', user_id=13, bot=True)
+    await skid.on_message(robot)
+    normal = make_message('just deployed the new release', user_id=14)
+    await skid.on_message(normal)
+    assert robot.replies == [] and normal.replies == []
+
+
+async def test_disabled_switch(monkeypatch):
+    monkeypatch.setenv('SKID_DETECTOR_ENABLED', 'false')
+    cog = SkidDetector(bot=types.SimpleNamespace())
+    msg = make_message('teach me to hack', user_id=15)
+    await cog.on_message(msg)
+    assert msg.replies == []


### PR DESCRIPTION
A gag cog, **explicitly not moderation** — it never flags, logs, stores, or
reports anyone. When a message trips a skiddie pattern it *sometimes* replies
with a deadpan mock "threat readout" ribbing the sender. **Everyone is a valid
victim**: no trust tiers, no owner bypass — getting caught by your own bot is
the joke.

Sample verdict:

> 🚨 **SKID DETECTOR** 🚨
> @you, our sensors detected **elite hacker energy**. Threat level: *downloaded Kali once*. Recommended action: read a man page. 🧢

Triggers on things like "teach me to hack my ex insta", "how do i ddos
someone", "is this illegal btw", "i downloaded kali im basically a hacker",
"grabbed his ip lets boot him offline", "mr robot taught me everything".

Two dials keep it fun rather than spammy:
- It only *considers* pattern matches, and even then fires with
  `SKID_FIRE_CHANCE` (0.30) — the surprise is the bit.
- A `SKID_COOLDOWN_SECONDS` (180) per-user cooldown stops detector-bombing.

Deliberately a little unfair (being occasionally wrong is funnier), but the
patterns dodge ordinary practitioner talk — "the ddos mitigation held up",
"kali is solid for pentesting engagements", "wrote a detection today" all stay
quiet, so the actual security pros in the room are mostly spared.

10 rotating verdicts, 18 patterns, on by default (`SKID_DETECTOR_ENABLED`).
411 unit tests pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)