### PR TITLE
fix: dedupe syndicated stories across feeds; one scheduler per category

### DIFF
--- a/penguin-overlord/cogs/apple_google_news.py
+++ b/penguin-overlord/cogs/apple_google_news.py
@@ -20,6 +20,7 @@ import xml.etree.ElementTree as ET
 import defusedxml.ElementTree as DET  # hardened parser for untrusted feed XML
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -191,7 +192,10 @@ class AppleGoogleNews(commands.Cog):
         self.session = None
         self.state_file = str(state_path('apple_google_news_state.json'))
         self.state = self._load_state()
-        self.news_auto_poster.start()
+        if autopost_enabled():
+            self.news_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
     
     async def cog_unload(self):
         self.news_auto_poster.cancel()

--- a/penguin-overlord/cogs/comics.py
+++ b/penguin-overlord/cogs/comics.py
@@ -35,6 +35,7 @@ import discord
 from discord.ext import commands, tasks
 
 from utils.state import save_json_state
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -87,7 +88,10 @@ class Comics(commands.Cog):
             self.state['channel_id'] = int(env_chan)
         
         # Start daily poster (9 AM UTC)
-        self.daily_comic_poster.start()
+        if autopost_enabled():
+            self.daily_comic_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
     
     async def _ensure_session(self):
         """Ensure aiohttp session is created"""

--- a/penguin-overlord/cogs/cve.py
+++ b/penguin-overlord/cogs/cve.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 from html import unescape
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -79,7 +80,10 @@ class CVENews(commands.Cog):
         self.session = None
         self.state_file = str(state_path('cve_state.json'))
         self.state = self._load_state()
-        self.cve_auto_poster.start()
+        if autopost_enabled():
+            self.cve_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
     
     def _load_state(self):
         """Load CVE poster state from file."""

--- a/penguin-overlord/cogs/cybersecurity_news.py
+++ b/penguin-overlord/cogs/cybersecurity_news.py
@@ -20,6 +20,7 @@ import xml.etree.ElementTree as ET
 import defusedxml.ElementTree as DET  # hardened parser for untrusted feed XML
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -728,7 +729,10 @@ class CybersecurityNews(commands.Cog):
         self.session = None
         self.state_file = str(state_path('cybersecurity_news_state.json'))
         self.state = self._load_state()
-        self.news_auto_poster.start()
+        if autopost_enabled():
+            self.news_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
     
     async def cog_unload(self):
         self.news_auto_poster.cancel()

--- a/penguin-overlord/cogs/eu_legislation.py
+++ b/penguin-overlord/cogs/eu_legislation.py
@@ -22,6 +22,7 @@ from html import unescape
 from typing import Optional, Literal
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +56,10 @@ class EULegislation(commands.Cog):
         self.session = None
         self.state_file = str(state_path('eu_legislation_state.json'))
         self.posted_items = self._load_state()
-        self.legislation_auto_poster.start()
+        if autopost_enabled():
+            self.legislation_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
         logger.info("EU Legislation cog loaded")
     
     async def cog_unload(self):

--- a/penguin-overlord/cogs/gaming_news.py
+++ b/penguin-overlord/cogs/gaming_news.py
@@ -20,6 +20,7 @@ import xml.etree.ElementTree as ET
 import defusedxml.ElementTree as DET  # hardened parser for untrusted feed XML
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -98,7 +99,10 @@ class GamingNews(commands.Cog):
         self.session = None
         self.state_file = str(state_path('gaming_news_state.json'))
         self.state = self._load_state()
-        self.news_auto_poster.start()
+        if autopost_enabled():
+            self.news_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
     
     async def cog_unload(self):
         self.news_auto_poster.cancel()

--- a/penguin-overlord/cogs/general_news.py
+++ b/penguin-overlord/cogs/general_news.py
@@ -12,6 +12,7 @@ from discord.ext import commands, tasks
 import aiohttp
 
 from utils.http import client_session
+from utils.news_dedupe import autopost_enabled, seen_in_any
 import asyncio
 import re
 import logging
@@ -97,7 +98,10 @@ class GeneralNews(commands.Cog):
         self.session = None
         self.state_file = str(state_path('general_news_state.json'))
         self.posted_items = self._load_state()
-        self.news_auto_poster.start()
+        if autopost_enabled():
+            self.news_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — general news left to external timers")
         logger.info("General News cog loaded")
     
     async def cog_unload(self):
@@ -237,11 +241,13 @@ class GeneralNews(commands.Cog):
                         link_elem = item.find('link')
                         link = link_elem.text.strip() if link_elem is not None and link_elem.text else source['url']
                     
-                    # Check if already posted
+                    # Check if already posted — by ANY source, not just this
+                    # one: BBC syndicates a story into several of our feeds
+                    # (issue #49), so the check must span all of them.
                     if source_key not in self.posted_items:
                         self.posted_items[source_key] = []
-                    
-                    if skip_posted and link in self.posted_items[source_key]:
+
+                    if skip_posted and seen_in_any(self.posted_items.values(), link):
                         continue  # Skip already posted
                     
                     # Extract description

--- a/penguin-overlord/cogs/kev.py
+++ b/penguin-overlord/cogs/kev.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from html import unescape
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +52,10 @@ class KEVNews(commands.Cog):
         self.session = None
         self.state_file = str(state_path('kev_state.json'))
         self.state = self._load_state()
-        self.kev_auto_poster.start()
+        if autopost_enabled():
+            self.kev_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
     
     def _load_state(self):
         """Load KEV poster state from file."""

--- a/penguin-overlord/cogs/tech_news.py
+++ b/penguin-overlord/cogs/tech_news.py
@@ -20,6 +20,7 @@ import xml.etree.ElementTree as ET
 import defusedxml.ElementTree as DET  # hardened parser for untrusted feed XML
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -142,7 +143,10 @@ class TechNews(commands.Cog):
         self.session = None
         self.state_file = str(state_path('tech_news_state.json'))
         self.state = self._load_state()
-        self.news_auto_poster.start()
+        if autopost_enabled():
+            self.news_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
     
     async def cog_unload(self):
         self.news_auto_poster.cancel()

--- a/penguin-overlord/cogs/uk_legislation.py
+++ b/penguin-overlord/cogs/uk_legislation.py
@@ -22,6 +22,7 @@ from html import unescape
 from typing import Optional, Literal
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -45,7 +46,10 @@ class UKLegislation(commands.Cog):
         self.session = None
         self.state_file = str(state_path('uk_legislation_state.json'))
         self.posted_items = self._load_state()
-        self.legislation_auto_poster.start()
+        if autopost_enabled():
+            self.legislation_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
         logger.info("UK Legislation cog loaded")
     
     async def cog_unload(self):

--- a/penguin-overlord/cogs/us_legislation.py
+++ b/penguin-overlord/cogs/us_legislation.py
@@ -22,6 +22,7 @@ from html import unescape
 from typing import Optional, Literal
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +61,10 @@ class USLegislation(commands.Cog):
         self.session = None
         self.state_file = str(state_path('us_legislation_state.json'))
         self.posted_items = self._load_state()
-        self.legislation_auto_poster.start()
+        if autopost_enabled():
+            self.legislation_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
         logger.info("US Legislation cog loaded")
     
     async def cog_unload(self):

--- a/penguin-overlord/cogs/vendor_alerts.py
+++ b/penguin-overlord/cogs/vendor_alerts.py
@@ -18,6 +18,7 @@ import html
 from datetime import datetime, timezone
 
 from utils.state import load_json_state, save_json_state, state_path
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -302,7 +303,10 @@ class VendorAlerts(commands.Cog):
         self.session = None
         self.state_file = str(state_path('vendor_alerts_state.json'))
         self.state = self._load_state()
-        self.vendor_alerts_auto_poster.start()
+        if autopost_enabled():
+            self.vendor_alerts_auto_poster.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
     
     def _load_state(self):
         """Load vendor alerts state from file."""

--- a/penguin-overlord/cogs/xkcd_poster.py
+++ b/penguin-overlord/cogs/xkcd_poster.py
@@ -30,6 +30,7 @@ import discord
 from discord.ext import commands, tasks
 
 from utils.state import load_json_state, save_json_state
+from utils.news_dedupe import autopost_enabled
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +73,10 @@ class XKCDPoster(commands.Cog):
         self.poll_loop.change_interval(minutes=self.poll_minutes)
         
         # Start background task
-        self.poll_loop.start()
+        if autopost_enabled():
+            self.poll_loop.start()
+        else:
+            logger.info("NEWS_AUTO_POST disabled — auto-posting left to external timers")
 
     def cog_unload(self):
         try:

--- a/penguin-overlord/utils/news_dedupe.py
+++ b/penguin-overlord/utils/news_dedupe.py
@@ -1,0 +1,70 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Shared helpers for news deduplication and auto-post gating (issue #49).
+
+Feeds from the same publisher syndicate one story into several feeds (BBC Top
+Stories vs UK vs Politics), so dedupe state keyed per feed lets the same
+article through once per feed. These helpers compare an item against the
+union of every feed's seen-list, with light URL normalization so tracking
+parameters and fragments don't defeat the comparison.
+"""
+
+import os
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+
+# Query parameters that vary between syndications of the same article.
+_TRACKING_PREFIXES = ('utm_', 'at_', 'ns_', 'cmp', 'ocid', 'ref')
+
+
+def normalize_link(value: str) -> str:
+    """Normalize a URL-shaped GUID/link for duplicate comparison.
+
+    Strips the fragment and tracking query parameters, lowercases the host,
+    and drops a trailing slash. Non-URL strings are returned unchanged so
+    opaque GUIDs still compare exactly.
+    """
+    if not value:
+        return value
+    value = value.strip()
+    if not value.startswith(('http://', 'https://')):
+        return value
+    try:
+        scheme, netloc, path, query, _fragment = urlsplit(value)
+    except ValueError:
+        return value
+    kept = [
+        (k, v) for k, v in parse_qsl(query, keep_blank_values=True)
+        if not k.lower().startswith(_TRACKING_PREFIXES)
+    ]
+    path = path.rstrip('/') or ''
+    return urlunsplit((scheme, netloc.lower(), path, urlencode(kept), ''))
+
+
+def seen_in_any(seen_lists, value: str) -> bool:
+    """True if `value` matches an entry in ANY of the given seen-lists.
+
+    `seen_lists` is an iterable of lists (e.g. dict.values() of a per-feed
+    seen mapping). Comparison uses normalize_link on both sides.
+    """
+    if not value:
+        return False
+    target = normalize_link(value)
+    for entries in seen_lists:
+        for entry in entries:
+            if normalize_link(entry) == target:
+                return True
+    return False
+
+
+def autopost_enabled() -> bool:
+    """Whether in-bot news auto-post loops should run (NEWS_AUTO_POST).
+
+    Defaults to enabled so standalone deployments keep posting. Set
+    NEWS_AUTO_POST=false where the systemd news timers own posting, so the
+    same category is never posted by two schedulers with separate state.
+    """
+    return os.getenv('NEWS_AUTO_POST', 'true').strip().lower() not in (
+        'false', '0', 'no', 'off',
+    )

--- a/penguin-overlord/utils/news_fetcher.py
+++ b/penguin-overlord/utils/news_fetcher.py
@@ -18,6 +18,7 @@ from typing import Optional, Tuple, Dict, List
 from collections import defaultdict
 
 from utils.state import load_json_state, save_json_state
+from utils.news_dedupe import seen_in_any
 
 logger = logging.getLogger(__name__)
 
@@ -165,9 +166,10 @@ class OptimizedNewsFetcher:
                 
                 guid = guid_match.group(1).strip() if guid_match else None
                 
-                # Check if we've already seen this GUID
-                last_guids = self.feed_cache['last_guids'].get(url, [])
-                if guid and guid in last_guids:
+                # Check if we've already seen this GUID — on ANY feed, not just
+                # this one: publishers syndicate a story into several feeds
+                # (issue #49), so the check must span the whole category.
+                if guid and seen_in_any(self.feed_cache['last_guids'].values(), guid):
                     continue  # Skip already posted items
                 
                 # Extract title

--- a/tests/unit/test_news_dedupe.py
+++ b/tests/unit/test_news_dedupe.py
@@ -1,0 +1,190 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Regression tests for issue #49: duplicated news posts.
+
+Two root causes:
+
+1. Cross-feed duplication — dedupe state was keyed per feed URL (runner) or
+   per source key (cogs), so the same BBC story syndicated into Top Stories
+   AND the UK feed posted once per feed.
+
+2. Cross-poster duplication — every news cog starts its own in-bot auto-post
+   loop even when the systemd news timers run the same category externally,
+   with separate state files, so each article could post twice with slightly
+   different formatting. NEWS_AUTO_POST=false must keep the loops parked.
+"""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from cogs import general_news
+from utils.news_fetcher import OptimizedNewsFetcher
+
+
+# ---------------------------------------------------------------------------
+# Runner path: OptimizedNewsFetcher GUID dedupe must span all feeds
+# ---------------------------------------------------------------------------
+
+RSS_ONE_STORY = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <title>BBC UK</title>
+  <item>
+    <title>Same story, different feed</title>
+    <link>https://www.bbc.co.uk/news/articles/abc123</link>
+    <guid>https://www.bbc.co.uk/news/articles/abc123</guid>
+    <description>One story syndicated into several BBC feeds.</description>
+    <pubDate>Mon, 31 Aug 2026 12:00:00 GMT</pubDate>
+  </item>
+</channel></rss>
+"""
+
+
+@pytest.fixture
+def fetcher(tmp_data_dir):
+    return OptimizedNewsFetcher(cache_file=str(tmp_data_dir / "feed_cache_test.json"))
+
+
+def test_fetcher_skips_guid_seen_on_sibling_feed(fetcher):
+    """A GUID recorded for one feed URL must suppress the item on every feed."""
+    fetcher.feed_cache["last_guids"]["https://feeds.bbci.co.uk/news/rss.xml"] = [
+        "https://www.bbc.co.uk/news/articles/abc123"
+    ]
+
+    result = fetcher._parse_feed_content(
+        RSS_ONE_STORY, "https://feeds.bbci.co.uk/news/uk/rss.xml", "BBC UK"
+    )
+
+    assert result is None
+
+
+def test_fetcher_treats_tracking_variants_as_same_guid(fetcher):
+    """Fragment / tracking-parameter variants of a URL GUID are the same story."""
+    fetcher.feed_cache["last_guids"]["https://feeds.bbci.co.uk/news/rss.xml"] = [
+        "https://www.bbc.co.uk/news/articles/abc123?at_medium=RSS&at_campaign=rss#0"
+    ]
+
+    result = fetcher._parse_feed_content(
+        RSS_ONE_STORY, "https://feeds.bbci.co.uk/news/uk/rss.xml", "BBC UK"
+    )
+
+    assert result is None
+
+
+def test_fetcher_still_returns_genuinely_new_item(fetcher):
+    """The global check must not suppress stories that were never posted."""
+    fetcher.feed_cache["last_guids"]["https://feeds.bbci.co.uk/news/rss.xml"] = [
+        "https://www.bbc.co.uk/news/articles/zzz999"
+    ]
+
+    result = fetcher._parse_feed_content(
+        RSS_ONE_STORY, "https://feeds.bbci.co.uk/news/uk/rss.xml", "BBC UK"
+    )
+
+    assert result is not None
+    assert result[0] == "Same story, different feed"
+
+
+# ---------------------------------------------------------------------------
+# Cog path: GeneralNews link dedupe must span all sources
+# ---------------------------------------------------------------------------
+
+GENERAL_RSS = """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"><channel>
+  <title>BBC UK</title>
+  <item>
+    <title>Shared headline</title>
+    <link>https://www.bbc.co.uk/news/articles/abc123</link>
+    <description>Story in both Top Stories and UK.</description>
+    <pubDate>Mon, 31 Aug 2026 12:00:00 GMT</pubDate>
+  </item>
+</channel></rss>
+"""
+
+
+class FakeResponse:
+    def __init__(self, text, status=200):
+        self._text = text
+        self.status = status
+
+    async def text(self):
+        return self._text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class FakeSession:
+    def __init__(self, text):
+        self._text = text
+        self.closed = False
+
+    def get(self, url, **kwargs):
+        return FakeResponse(self._text)
+
+
+@pytest.fixture
+def news_cog(tmp_data_dir):
+    instance = general_news.GeneralNews.__new__(general_news.GeneralNews)
+    instance.bot = MagicMock()
+    instance.session = FakeSession(GENERAL_RSS)
+    instance.state_file = str(tmp_data_dir / "general_news_state.json")
+    instance.posted_items = {}
+    return instance
+
+
+async def test_cog_skips_link_posted_by_sibling_source(news_cog):
+    """A link already posted from bbc_top must not post again from bbc_uk."""
+    news_cog.posted_items["bbc_top"] = ["https://www.bbc.co.uk/news/articles/abc123"]
+
+    result = await news_cog._fetch_rss_feed("bbc_uk")
+
+    assert result is None
+
+
+async def test_cog_skips_tracking_variant_of_posted_link(news_cog):
+    """Tracking-parameter variants of an already-posted link are duplicates."""
+    news_cog.posted_items["bbc_top"] = [
+        "https://www.bbc.co.uk/news/articles/abc123?at_medium=RSS#0"
+    ]
+
+    result = await news_cog._fetch_rss_feed("bbc_uk")
+
+    assert result is None
+
+
+async def test_cog_returns_genuinely_new_item(news_cog):
+    news_cog.posted_items["bbc_top"] = ["https://www.bbc.co.uk/news/articles/zzz999"]
+
+    result = await news_cog._fetch_rss_feed("bbc_uk")
+
+    assert result is not None
+    assert result[0] == "Shared headline"
+
+
+# ---------------------------------------------------------------------------
+# Cross-poster: NEWS_AUTO_POST=false parks the in-bot auto-post loops
+# ---------------------------------------------------------------------------
+
+async def test_auto_post_gate_disables_loop(tmp_data_dir, monkeypatch):
+    monkeypatch.setenv("NEWS_AUTO_POST", "false")
+    cog = general_news.GeneralNews(MagicMock())
+    try:
+        assert not cog.news_auto_poster.is_running()
+    finally:
+        cog.news_auto_poster.cancel()
+
+
+async def test_auto_post_defaults_to_enabled(tmp_data_dir, monkeypatch):
+    monkeypatch.delenv("NEWS_AUTO_POST", raising=False)
+    cog = general_news.GeneralNews(MagicMock())
+    try:
+        assert cog.news_auto_poster.is_running()
+    finally:
+        cog.news_auto_poster.cancel()


### PR DESCRIPTION
Closes #49. Supersedes #55.

## Two root causes, both fixed

**Cross-feed duplication** — dedupe state was keyed per feed URL ([news_fetcher](penguin-overlord/utils/news_fetcher.py)) or per source key ([general_news](penguin-overlord/cogs/general_news.py)), so one BBC story syndicated into Top Stories + UK posted once per feed. Both paths now check the union of every feed's seen-list via the new `utils/news_dedupe.py`, with URL normalization (fragments, `utm_`/`at_`-style tracking params, host case) so syndication variants still match.

**Cross-poster duplication** — every news cog unconditionally starts its own in-bot auto-post loop even when the systemd `penguin-news-*` timers run the same category externally with separate state files. Same article, two posts, different formatting (the "some have emojis leading" in the report). New `NEWS_AUTO_POST` env gate (default `true` — standalone deployments unchanged) parks the in-bot loops in 13 cogs where timers own posting. The explicit `/cve enable`-style admin commands still start their loops regardless.

## Tests
8 new tests in `tests/unit/test_news_dedupe.py` covering both dedupe paths, tracking-variant matching, the no-false-positive control, and the env gate in both states. Full suite: 419 passed, 1 skipped. Watched each fail before implementing.

## Deploy note
Set `NEWS_AUTO_POST=false` in the box .env so the timers are the single scheduler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)