### PR TITLE
fix: skid detector catches "learn to hack" phrasing

### DIFF
--- a/penguin-overlord/cogs/skid_detector.py
+++ b/penguin-overlord/cogs/skid_detector.py
@@ -39,7 +39,10 @@ logger = logging.getLogger(__name__)
 # unfair — being occasionally wrong is funnier than being precise.
 _SKID_PATTERNS = [
     r'\bteach me (?:how )?to hack\b',
-    r'\bhow (?:do i|to|can i) (?:hack|ddos|dox|crack|breach|pwn|boot|swat)\b',
+    # "learn to hack" is the quintessential skid opener; catch it on its own
+    # and after the usual "how do i / wanna / i want to" run-ups.
+    r'\b(?:wanna|want to|trying to|tryna|gonna|how (?:do i|to|can i))?\s*learn(?:ing)? (?:how )?to (?:hack|ddos|dox|crack|breach|pwn|swat)\b',
+    r'\bhow (?:do i|to|can i) (?:learn (?:how )?to )?(?:hack|ddos|dox|crack|breach|pwn|boot|swat)\b',
     r'\bhow (?:do i|to|can i) (?:get|become) (?:a )?hacker\b',
     r'\bhack (?:my|his|her|their|this|that|the) (?:ex|gf|bf|friend|account|insta|snap|wifi|school)\b',
     r'\b(?:give|send|got|need|want) (?:me )?(?:a )?(?:rat|botnet|stealer|logger|cheat|crypter|c2)\b',

--- a/tests/unit/test_skid_detector.py
+++ b/tests/unit/test_skid_detector.py
@@ -49,6 +49,9 @@ def test_recognises_skid_energy():
         'grabbed his ip lets boot him offline',
         "what's the best hacking app",
         'mr robot taught me everything',
+        'Hey Guys how can I learn to hack?',
+        'i wanna learn to hack',
+        'learning how to hack pls',
     ):
         assert looks_like_skid(text), text
 
@@ -60,6 +63,8 @@ def test_ordinary_talk_is_not_skid():
         'kali is a solid distro for pentesting engagements',
         'anyone else watching the game tonight',
         'i love my new keyboard',
+        'i love learning to cook',
+        'how can i learn python',
     ):
         assert not looks_like_skid(text), text
 


### PR DESCRIPTION
## What

The skid detector stayed silent on **"Hey Guys how can I learn to hack?"** — the single most iconic script-kiddie opener.

## Why it missed

- The existing `how (do i|to|can i) (hack|ddos|...)` pattern needed the verb to follow **immediately**, so the intervening "learn to" broke the match.
- There was no standalone `learn(ing) to hack` pattern at all.

## Fix

- New dedicated pattern for `learn to hack` with the usual `wanna` / `want to` / `tryna` / `how do i` run-ups.
- The `how do i` pattern now tolerates an optional `learn (how) to`.

Deliberately stays broad but avoids obvious false positives: past-tense storytelling ("I **learned** to hack the mainframe in this movie"), "learning to cook", and "how can i learn python" all correctly stay silent. Regression cases added in both directions.

Note: this is the pattern gate only. Even on a match the detector still fires at `SKID_FIRE_CHANCE` (default 0.30) by design — set it to `1.0` temporarily to test reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)