### PR TITLE
fix: spurious guard flags get a second look before alerting mods

### DIFF
--- a/penguin-overlord/ai/features/moderation.py
+++ b/penguin-overlord/ai/features/moderation.py
@@ -534,19 +534,40 @@ class ModerationAnalyzer:
             # entirely" -> unknown, red-team label: noise). Ask the
             # context-capable second model; a confident 'safe' suppresses,
             # anything else keeps the review alert (fail open).
-            cleared = await self._unknown_second_look(
+            cleared = await self._fp_second_look(
                 safe_content, username, channel_name, context_messages,
-                infraction_count,
+                infraction_count, 'unmapped guard code cleared by second opinion',
             )
             if cleared is not None:
                 return cleared
+        elif (not result.denylist_hit
+                and result.category in _second_opinion_categories()):
+            # The guard is precise but context-blind, and can throw a
+            # spurious verdict under load (measured live: "Mozal Tov" ->
+            # unsafe S10 hate once, safe on ten replays). A hate/harassment
+            # flag it raises WITHOUT a deny-list hit gets the same
+            # context-capable second look the unmapped codes get: a
+            # confident 'safe' clears it, anything else keeps the alert
+            # (fail open). Deny-list hits and every category outside
+            # SECOND_OPINION_CATEGORIES (doxxing, sexual_content, ...) are
+            # never second-guessed downward.
+            cleared = await self._fp_second_look(
+                safe_content, username, channel_name, context_messages,
+                infraction_count,
+                f'guard {result.category} flag cleared by second opinion',
+            )
+            if cleared is not None:
+                logger.info('Guard %s flag (%.2f) cleared by second opinion',
+                            result.category, result.confidence)
+                return cleared
         return result
 
-    async def _unknown_second_look(self, safe_content, username, channel_name,
-                                   context_messages, infraction_count):
-        """Second opinion on an 'unknown' (unmapped guard code) verdict.
-        Returns a safe ModerationResult to use instead, or None to keep
-        the original review alert."""
+    async def _fp_second_look(self, safe_content, username, channel_name,
+                              context_messages, infraction_count,
+                              cleared_reason):
+        """Ask the context-capable second model whether a primary flag is a
+        false positive. Returns a safe ModerationResult to use instead, or
+        None to keep the original alert (fail open)."""
         model = _second_opinion_model()
         if not model or is_guard_model(model):
             return None
@@ -558,7 +579,7 @@ class ModerationAnalyzer:
                 system_prompt=moderation_system_prompt(), raw=True, model=model,
             )
         except Exception as e:
-            logger.error(f"Unknown-code second look failed: {type(e).__name__}")
+            logger.error(f"False-positive second look failed: {type(e).__name__}")
             return None
         if not raw:
             return None
@@ -566,7 +587,7 @@ class ModerationAnalyzer:
         if second.is_safe and second.confidence >= 0.8:
             return ModerationResult(
                 True, 'safe', second.confidence,
-                f"unmapped guard code cleared by second opinion ({model})",
+                f"{cleared_reason} ({model})",
                 'none',
             )
         return None

--- a/tests/unit/test_moderation.py
+++ b/tests/unit/test_moderation.py
@@ -352,14 +352,16 @@ async def test_second_opinion_low_conf_harassment_ignored(monkeypatch):
     assert r.is_safe
 
 
-async def test_second_opinion_skipped_when_primary_flags(monkeypatch):
+async def test_guard_hate_flag_kept_when_second_agrees(monkeypatch):
+    # A guard hate flag now gets a context-capable second look; the second
+    # model agreeing unsafe keeps the alert.
     monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
     monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma3:12b')
     manager = TwoStageManager('unsafe\nS10', SECOND_HATE)
     analyzer = ModerationAnalyzer(manager)
     r = await analyzer.analyze('some flagged message', 'x')
     assert not r.is_safe and r.category == 'hate_speech'
-    assert len(manager.calls) == 1
+    assert len(manager.calls) == 2
 
 
 async def test_second_opinion_off_by_default(monkeypatch):
@@ -410,6 +412,76 @@ async def test_unknown_guard_code_kept_without_second_model(monkeypatch):
     analyzer = ModerationAnalyzer(TwoStageManager('unsafe\nS8', SECOND_SAFE))
     r = await analyzer.analyze('I bypassed it entirely already', 'x')
     assert not r.is_safe and r.category == 'unknown'
+
+
+# -- guard false positives cleared by the second stage ------------------------
+
+async def test_spurious_guard_hate_flag_cleared_by_second_opinion(monkeypatch):
+    # The Mozal Tov incident: the guard threw unsafe S10 hate at a Yiddish
+    # congratulation once under load (safe on ten replays). A confident
+    # 'safe' from the context-capable second model clears the alert.
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma4:12b')
+    manager = TwoStageManager('unsafe\nS10', SECOND_SAFE)
+    analyzer = ModerationAnalyzer(manager)
+    r = await analyzer.analyze('Mozal Tov', 'x')
+    assert r.is_safe
+    assert 'guard hate_speech flag cleared by second opinion' in r.reason
+    # Second pass used the rich template prompt on the flagged content
+    assert 'MESSAGE UNDER REVIEW' in manager.calls[1]['prompt']
+
+
+async def test_low_confidence_second_safe_keeps_guard_flag(monkeypatch):
+    # Only a CONFIDENT safe clears — an uncertain second stage fails open.
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma4:12b')
+    unsure = SECOND_SAFE.replace('0.95', '0.7')
+    analyzer = ModerationAnalyzer(TwoStageManager('unsafe\nS10', unsure))
+    r = await analyzer.analyze('ambiguous phrasing', 'x')
+    assert not r.is_safe and r.category == 'hate_speech'
+
+
+async def test_denylist_hit_never_cleared_by_second_opinion(monkeypatch):
+    # Deny-list terms are the hard floor: the second stage must never talk
+    # the pipeline out of a slur alert (that path belongs to the reclaimed-
+    # language adjudication with its trust-tier rules, not to this one).
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma4:12b')
+    from ai.features.moderation import find_blocked_terms
+    slur = None
+    for candidate in ('kike', 'faggot'):
+        if find_blocked_terms(candidate):
+            slur = candidate
+            break
+    if slur is None:
+        pytest.skip('no deny-list term available in test environment')
+    manager = TwoStageManager('unsafe\nS10', SECOND_SAFE)
+    analyzer = ModerationAnalyzer(manager)
+    r = await analyzer.analyze(slur, 'x')
+    assert not r.is_safe
+    assert len(manager.calls) == 1          # no second look at all
+
+
+async def test_guard_doxxing_flag_not_second_guessed(monkeypatch):
+    # Categories outside SECOND_OPINION_CATEGORIES (doxxing S7, etc.) go
+    # straight to review — gemma is only trusted on hate/harassment.
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.setenv('AI_MODERATION_SECOND_MODEL', 'gemma4:12b')
+    manager = TwoStageManager('unsafe\nS7', SECOND_SAFE)
+    analyzer = ModerationAnalyzer(manager)
+    r = await analyzer.analyze('john lives at 12 elm street', 'x')
+    assert not r.is_safe and r.category == 'doxxing'
+    assert len(manager.calls) == 1
+
+
+async def test_guard_flag_kept_without_second_model(monkeypatch):
+    monkeypatch.setenv('AI_MODERATION_MODEL', 'llama-guard3:8b')
+    monkeypatch.delenv('AI_MODERATION_SECOND_MODEL', raising=False)
+    manager = TwoStageManager('unsafe\nS10', SECOND_SAFE)
+    analyzer = ModerationAnalyzer(manager)
+    r = await analyzer.analyze('anything', 'x')
+    assert not r.is_safe and r.category == 'hate_speech'
+    assert len(manager.calls) == 1
 
 
 # -- guard-model prompt isolation --------------------------------------------


### PR DESCRIPTION
## The incident

The guard flagged **"Mozal Tov"** — a Yiddish congratulation, on a server run by and full of Jewish members — as `hate_speech` at 0.95 and alerted the mod channel.

## Diagnosis

- Pulled the stored excerpt: **pure ASCII, nine characters**, no invisible chars, no homoglyphs.
- Replayed the exact bytes through the live analyzer **ten times: safe every time** (0.85).
- Verdict: a one-off guard flip under load (dual-resident models, batching state) — not reproducible, not content-driven.

## The real gap it exposed

| Guard verdict | Second look? |
|---|---|
| safe (missed hate) | ✅ gemma escalation |
| unsafe, unmapped S-code | ✅ gemma can clear |
| **unsafe, mapped category** | ❌ **straight to alert — nobody checks** |

## Fix

A guard `hate_speech`/`harassment` flag **without a deny-list hit** now gets the same context-capable second look: gemma with full context + community profile judges it, a **confident safe (≥0.8) clears** the alert, anything else keeps it (**fail open**). Guardrails:

- **Deny-list hits are never second-guessed downward** — that path stays with the reclaimed-language adjudication and its trust-tier rules.
- Categories outside `SECOND_OPINION_CATEGORIES` (doxxing, sexual_content, …) still go straight to review.
- No second model configured → behavior unchanged.

`_unknown_second_look` generalized into `_fp_second_look`, shared by both clearing paths. Cost: one extra gemma call per guard flag — flags are rare.

## Tests

429 passed. New regression coverage: the Mozal Tov case (spurious flag cleared), low-confidence safe fails open, deny-list exempt, doxxing not second-guessed, no-second-model unchanged; updated the test that encoded the old skip-on-flag behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)