### PR TITLE
feat: greeter fires on the quarter hour, both stages

### DIFF
--- a/penguin-overlord/cogs/welcome_greeter.py
+++ b/penguin-overlord/cogs/welcome_greeter.py
@@ -17,11 +17,12 @@ that role is what unlocks #general. Each moment gets its own greeting:
                     the members who just earned their way in.
 
 Both stages share the same batching engine (`_GreetStage`): members are
-collected and flushed together on a tick, at most one message per stage per
-its own cooldown — so a wave of arrivals is one message naming several, and
-a quiet window is silence. The rendered message always fits Discord's
-2000-character limit; very large batches (a MEE6 bulk role re-sync) mention
-the first few and count the rest.
+collected and flushed together at most once per stage per its window,
+ALIGNED TO THE WALL CLOCK — the default 900s window means greetings go out
+on the quarter hour (:00/:15/:30/:45), so a wave of arrivals is one message
+naming several, and a quiet window is silence. The rendered message always
+fits Discord's 2000-character limit; very large batches (a MEE6 bulk role
+re-sync) mention the first few and count the rest.
 
 Each member is greeted at most once per stage, persisted under `data/`
 (join → `welcomed_newbies.json`, verify → `welcomed_users.json`), so role
@@ -44,7 +45,8 @@ Configuration:
     WELCOME_JOIN_ENABLED=true        (within WELCOME_ENABLED)
     WELCOME_JOIN_CHANNEL_ID=         where newcomers first land
     WELCOME_JOIN_MESSAGE=            template: {users}{rules}{roles}{wagon}{general}
-    WELCOME_JOIN_COOLDOWN_SECONDS=60 at most one join message per this
+    WELCOME_JOIN_COOLDOWN_SECONDS=900  window length; flushes align to
+                                     wall-clock multiples (900 = the quarter hour)
     WELCOME_JOIN_IMAGE=              attached image ('' = none)
 
   Stage 2 — verify (Costco → #general):
@@ -52,7 +54,8 @@ Configuration:
     WELCOME_ROLE_ID=                 the role whose grant means "verified"
     WELCOME_VERIFY_CHANNEL_ID=       where to greet (defaults to WELCOME_CHANNEL_ID)
     WELCOME_VERIFY_MESSAGE=          template: {users}{roles}
-    WELCOME_VERIFY_COOLDOWN_SECONDS=300  at most one verify message per this
+    WELCOME_VERIFY_COOLDOWN_SECONDS=900  window length; flushes align to
+                                     wall-clock multiples (900 = the quarter hour)
     WELCOME_VERIFY_IMAGE=            attached image ('' = none)
     WELCOME_MAX_TENURE_DAYS=30       only greet members who JOINED this
                                      recently (0 disables the gate)
@@ -125,8 +128,9 @@ def _env_id(name: str):
 
 
 class _GreetStage:
-    """One batched greeting flow. Collects members, flushes them together
-    once per `cooldown`, greets each at most once ever (persisted)."""
+    """One batched greeting flow. Collects members, flushes them together at
+    most once per `cooldown`-second window ALIGNED TO THE WALL CLOCK (900 →
+    on the quarter hour), greets each at most once ever (persisted)."""
 
     def __init__(self, bot, *, name, enabled, channel_id, template,
                  default_template, image_path, cooldown, max_mentions,
@@ -145,7 +149,11 @@ class _GreetStage:
         self.max_tenure_days = max_tenure_days
         self._welcomed = self._load()
         self._pending: list = []
-        self._last_flush = None              # monotonic; None = never flushed
+        # The clock-aligned window we last flushed in (or booted in): members
+        # queued during window N go out at the first tick of window N+1, so
+        # greetings land ON the boundary (:00/:15/:30/:45 for 900s), never
+        # mid-window right after a boot.
+        self._last_period = int(time.time() // self.cooldown)
 
     # ------------------------------------------------------------ storage
 
@@ -222,15 +230,17 @@ class _GreetStage:
     # -------------------------------------------------------------- flush
 
     def due(self, now: float) -> bool:
+        """Members are waiting and the wall clock has crossed into a new
+        `cooldown`-aligned window since the last flush."""
         if not self._pending:
             return False
-        return self._last_flush is None or (now - self._last_flush) >= self.cooldown
+        return int(now // self.cooldown) > self._last_period
 
     async def _flush(self):
         if not self._pending:
             return
         members, self._pending = self._pending, []
-        self._last_flush = time.monotonic()
+        self._last_period = int(time.time() // self.cooldown)
 
         channel = self.bot.get_channel(self.channel_id)
         if channel is None:
@@ -286,7 +296,7 @@ class WelcomeGreeter(commands.Cog):
             template=_env('WELCOME_JOIN_MESSAGE'),
             default_template=MICROCENTER_MESSAGE,
             image_path=_env('WELCOME_JOIN_IMAGE', MICROCENTER_IMAGE),
-            cooldown=float(_env('WELCOME_JOIN_COOLDOWN_SECONDS', '60')),
+            cooldown=float(_env('WELCOME_JOIN_COOLDOWN_SECONDS', '900')),
             max_mentions=max_mentions,
             welcomed_file='welcomed_newbies.json',
             refs=refs,
@@ -298,7 +308,7 @@ class WelcomeGreeter(commands.Cog):
             template=_env('WELCOME_VERIFY_MESSAGE'),
             default_template=COSTCO_MESSAGE,
             image_path=_env('WELCOME_VERIFY_IMAGE', COSTCO_IMAGE),
-            cooldown=float(_env('WELCOME_VERIFY_COOLDOWN_SECONDS', '300')),
+            cooldown=float(_env('WELCOME_VERIFY_COOLDOWN_SECONDS', '900')),
             max_mentions=max_mentions,
             welcomed_file='welcomed_users.json',   # keep the existing dedup file
             refs=refs,
@@ -317,16 +327,19 @@ class WelcomeGreeter(commands.Cog):
             self.verify.enabled = False
 
         self.enabled = self.join.enabled or self.verify.enabled
+        # The tick only CHECKS for window boundaries; it must run well inside
+        # the smallest window so a flush lands promptly after :00/:15/:30/:45.
         live = [s.cooldown for s in (self.join, self.verify) if s.enabled]
-        self._base_tick = min(live) if live else 60.0
+        self._base_tick = min([60.0] + live)
 
     async def cog_load(self):
         if not self.enabled:
             return
         self.greet_tick.change_interval(seconds=self._base_tick)
         self.greet_tick.start()
-        logger.info('Welcome greeter active: join=%s (-> %s, %.0fs, %d greeted), '
-                    'verify=%s (role %s -> %s, %.0fs, %d greeted); base tick %.0fs',
+        logger.info('Welcome greeter active: join=%s (-> %s, %.0fs windows, %d greeted), '
+                    'verify=%s (role %s -> %s, %.0fs windows, %d greeted); '
+                    'clock-aligned, base tick %.0fs',
                     self.join.enabled, self.join.channel_id, self.join.cooldown,
                     len(self.join._welcomed), self.verify.enabled, self.role_id,
                     self.verify.channel_id, self.verify.cooldown,
@@ -377,8 +390,9 @@ class WelcomeGreeter(commands.Cog):
 
     @tasks.loop(seconds=60)
     async def greet_tick(self):
-        """Each base tick, flush whichever stage's own cooldown has elapsed."""
-        now = time.monotonic()
+        """Each base tick, flush whichever stage has crossed into a new
+        clock-aligned window with members waiting."""
+        now = time.time()
         for stage in (self.join, self.verify):
             if stage.enabled and stage.due(now):
                 try:

--- a/tests/unit/test_welcome_and_rules.py
+++ b/tests/unit/test_welcome_and_rules.py
@@ -231,17 +231,47 @@ async def test_join_ignores_bots_and_never_double_greets(greeter):
     assert 9 in fresh.join._welcomed and 8 not in fresh.join._welcomed
 
 
-async def test_stage_cooldowns_gate_independently(greeter):
-    # Join defaults to 60s, verify to 300s: only the due stage flushes.
-    assert greeter.join.cooldown == 60
-    assert greeter.verify.cooldown == 300
-    now = 1_000_000.0
-    greeter.join._pending = [member(1)]
-    greeter.verify._pending = [member(2)]
-    greeter.join._last_flush = now - 65      # past its 60s cooldown
-    greeter.verify._last_flush = now - 65    # NOT past its 300s cooldown
-    assert greeter.join.due(now) is True
-    assert greeter.verify.due(now) is False
+async def test_greetings_fire_on_the_quarter_hour(greeter):
+    # Both stages default to 900s windows aligned to the wall clock: a
+    # member queued at :07 goes out at :15, not seconds after arriving.
+    assert greeter.join.cooldown == 900
+    assert greeter.verify.cooldown == 900
+    boundary = 1_800_000_000 - (1_800_000_000 % 900)   # a :00/:15/:30/:45 mark
+    for stage in (greeter.join, greeter.verify):
+        stage._pending = [member(1)]
+        stage._last_period = int((boundary + 60) // 900)   # queued at :01
+        assert stage.due(boundary + 120) is False          # :02 — same window
+        assert stage.due(boundary + 899) is False          # :14:59 — still waiting
+        assert stage.due(boundary + 901) is True           # :15:01 — boundary crossed
+
+
+async def test_flush_pins_the_stage_to_the_current_window(greeter):
+    # After a flush, nothing more goes out until the NEXT quarter hour even
+    # if new members arrive immediately.
+    greeter.verify._pending = [member(3)]
+    await greeter.verify._flush()
+    import time as _time
+    now = _time.time()
+    greeter.verify._pending = [member(4)]
+    assert greeter.verify.due(now) is False              # same window as the flush
+    assert greeter.verify.due(now + 900) is True         # next window
+
+
+async def test_boot_does_not_flush_mid_window(monkeypatch, tmp_path):
+    # A fresh boot must wait for the next clock boundary, not greet whoever
+    # queues within seconds of startup.
+    monkeypatch.setenv('DATA_DIR', str(tmp_path))
+    monkeypatch.setenv('WELCOME_ENABLED', 'true')
+    monkeypatch.setenv('WELCOME_ROLE_ID', str(ACCESS_ROLE))
+    monkeypatch.setenv('WELCOME_VERIFY_CHANNEL_ID', str(GENERAL))
+    monkeypatch.setenv('WELCOME_JOIN_CHANNEL_ID', str(NEWBIES))
+    cog = WelcomeGreeter(bot=types.SimpleNamespace())
+    import time as _time
+    now = _time.time()
+    cog.join._pending = [member(5)]
+    assert cog.join.due(now) is False                    # booted this window
+    next_boundary = (int(now // 900) + 1) * 900
+    assert cog.join.due(next_boundary + 1) is True
 
 
 async def test_disabled_without_channels(monkeypatch, tmp_path):


### PR DESCRIPTION
Both greeting stages were too chatty — join flushed every 60s, verify every 300s, from an arbitrary boot-relative clock. Now:

- **Both windows are 900s, aligned to the wall clock**: greetings land on **:00 / :15 / :30 / :45**, one batched message per stage per window at most.
- Members queued mid-window flush at the first tick after the boundary (max wait ~15 min).
- A **fresh boot waits for the next boundary** — no greeting whoever queues seconds after startup.
- A flush **pins the stage to its window**, so immediate follow-on arrivals wait for the next quarter hour.
- The 60s tick now only *checks* for boundary crossings.

`WELCOME_JOIN_COOLDOWN_SECONDS` / `WELCOME_VERIFY_COOLDOWN_SECONDS` keep their names and now mean the aligned window length (default 900). No box `.env` change needed — the defaults do it.

426 tests pass; new coverage for boundary gating, flush pinning, and the boot case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)