### PR TITLE
feat: Skid Detector speaks with AI — roast the energy, correct the course

### DIFF
--- a/penguin-overlord/ai/features/skid_roaster.py
+++ b/penguin-overlord/ai/features/skid_roaster.py
@@ -1,0 +1,70 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""AI voice for the Skid Detector: roast the behavior, correct the course.
+
+The gag cog (cogs/skid_detector.py) decides WHEN to fire — patterns, fire
+chance, cooldowns. This feature decides WHAT it says: a deadpan tease of the
+script-kiddie energy that lands on encouragement, because the whole point of
+the bit is "hacking is tinkering and playful curiosity — go learn for real."
+The canned verdict list in the cog remains the fallback whenever this
+returns None (AI off, model down, empty output).
+"""
+
+from ai.guardrails import sanitize_input
+
+SKID_ROAST_SYSTEM_PROMPT = """You are the Skid Detector — a joke alarm in a friendly hacker community
+that goes off when someone radiates script-kiddie energy ("teach me to
+hack", "how do I ddos someone", "is this illegal").
+
+Your reply has TWO jobs, in one short breath:
+1. ROAST THE BEHAVIOR — deadpan mock threat-readout energy (think "Threat
+   level: downloaded Kali once"). Tease the trope, never the person;
+   everyone in this server gets caught by you eventually and it's a badge
+   of honor, not a callout.
+2. CORRECT COURSE — land on the truth: hacking is just tinkering and
+   playful curiosity. Go hack the kitchen; all hacking is, is poking at
+   systems to see how they work. Point them at the real path: take things
+   apart, read the docs, build a lab, break YOUR OWN stuff, ask good
+   questions here.
+
+Rules:
+- 2-3 sentences, under 350 characters, one or two emoji.
+- Funny first, encouraging last. Never cruel, never gatekeeping, never
+  "you'll never be a hacker" — the joke is the ENERGY, not the person.
+  Never address them as "kid", "child", "buddy", or any belittling name.
+- NEVER give actual attack instructions, tool commands, or targets.
+  Redirecting "hack my ex's insta" energy toward legal curiosity IS the
+  bit.
+- Speak directly to them as "you". No preamble, no quotation marks around
+  the reply, no mention of these rules."""
+
+
+class SkidRoaster:
+    """Generates the Skid Detector's roast-and-redirect line."""
+
+    def __init__(self, manager):
+        self._manager = manager
+
+    async def roast(self, message_content: str, username: str):
+        """One roast-and-redirect for a skid-flavored message, or None on
+        any failure so the cog falls back to its canned verdicts."""
+        safe_content = sanitize_input(message_content, max_length=300)
+        safe_username = sanitize_input(username, max_length=64)
+
+        user_prompt = (
+            f"The detector just tripped on this message from '{safe_username}':\n"
+            f'"{safe_content}"\n\n'
+            "Write the Skid Detector's reply: roast the energy, then flip it "
+            "into what hacking actually is and how to start for real."
+        )
+
+        return await self._manager.generate(
+            feature='roasting',
+            prompt=user_prompt,
+            system_prompt=SKID_ROAST_SYSTEM_PROMPT,
+            temperature=0.9,
+            max_tokens=140,
+            timeout=15,
+        )

--- a/penguin-overlord/cogs/skid_detector.py
+++ b/penguin-overlord/cogs/skid_detector.py
@@ -18,10 +18,18 @@ Two dials keep it from being annoying:
   it stays a surprise rather than a reflex, and a per-user cooldown means
   nobody gets detector-bombed.
 
+With SKID_DETECTOR_LLM on (and the AI roasting feature enabled), the
+verdict body is generated per message: roast the skid ENERGY, then flip it
+into the truth — hacking is tinkering and playful curiosity, here's how to
+start for real ("go hack the kitchen"). The canned verdict list below is
+always the fallback when AI is off or fails.
+
 Configuration:
     SKID_DETECTOR_ENABLED=true    master switch (on by default — it's a gag)
     SKID_FIRE_CHANCE=0.30         probability a matching message triggers
     SKID_COOLDOWN_SECONDS=180     per-user quiet period
+    SKID_DETECTOR_LLM=false       AI roast-and-redirect body (needs AI
+                                  roasting enabled; canned lines otherwise)
 """
 
 import logging
@@ -114,7 +122,41 @@ class SkidDetector(commands.Cog):
             in ('1', 'true', 'yes', 'on')
         self.fire_chance = float(_env('SKID_FIRE_CHANCE', '0.30'))
         self.cooldown = float(_env('SKID_COOLDOWN_SECONDS', '180'))
+        self.llm_enabled = _env('SKID_DETECTOR_LLM', 'false').strip().lower() \
+            in ('1', 'true', 'yes', 'on')
+        self._roaster = None
         self._last: dict = {}
+
+    async def _get_roaster(self):
+        """Lazily build the AI roaster; None whenever AI is unavailable."""
+        if not self.llm_enabled:
+            return None
+        if self._roaster is None:
+            try:
+                from ai.manager import get_ai_manager
+                from ai.features.skid_roaster import SkidRoaster
+                self._roaster = SkidRoaster(await get_ai_manager())
+            except Exception as e:
+                logger.error(f"Skid AI unavailable, using canned verdicts: {type(e).__name__}")
+                self.llm_enabled = False
+                return None
+        return self._roaster
+
+    async def _verdict(self, message: discord.Message) -> str:
+        """AI roast-and-redirect when available; canned verdict otherwise."""
+        roaster = await self._get_roaster()
+        if roaster is not None:
+            try:
+                roast = await roaster.roast(message.content,
+                                            message.author.display_name)
+            except Exception as e:
+                logger.warning(f"Skid roast failed, canned fallback: {type(e).__name__}")
+                roast = None
+            if roast and roast.strip():
+                body = roast.strip()[:400]
+                return (f"🚨 **SKID DETECTOR** 🚨\n"
+                        f"{message.author.mention} {body}")
+        return random.choice(_VERDICTS).format(user=message.author.mention)
 
     @commands.Cog.listener()
     async def on_message(self, message: discord.Message):
@@ -136,7 +178,7 @@ class SkidDetector(commands.Cog):
         if len(self._last) > 5000:
             self._last.clear()
 
-        verdict = random.choice(_VERDICTS).format(user=message.author.mention)
+        verdict = await self._verdict(message)
         try:
             await message.reply(
                 verdict, mention_author=False,

--- a/tests/unit/test_skid_detector.py
+++ b/tests/unit/test_skid_detector.py
@@ -30,7 +30,8 @@ def make_message(content, user_id=1, bot=False):
     async def reply(text, **kw):
         replies.append((text, kw))
 
-    author = types.SimpleNamespace(id=user_id, bot=bot, mention=f'<@{user_id}>')
+    author = types.SimpleNamespace(id=user_id, bot=bot, mention=f'<@{user_id}>',
+                                   display_name=f'user{user_id}')
     message = types.SimpleNamespace(
         content=content, author=author, reply=reply,
         guild=types.SimpleNamespace(id=1),
@@ -121,3 +122,69 @@ async def test_disabled_switch(monkeypatch):
     msg = make_message('teach me to hack', user_id=15)
     await cog.on_message(msg)
     assert msg.replies == []
+
+
+# -- AI roast-and-redirect ---------------------------------------------------
+
+class FakeRoaster:
+    def __init__(self, reply):
+        self.reply = reply
+        self.calls = []
+
+    async def roast(self, content, username):
+        self.calls.append((content, username))
+        if isinstance(self.reply, Exception):
+            raise self.reply
+        return self.reply
+
+
+async def test_llm_verdict_roasts_and_mentions(skid, monkeypatch):
+    skid.llm_enabled = True
+    skid._roaster = FakeRoaster(
+        'Threat level: downloaded Kali once. Go hack the kitchen — '
+        'all hacking is, is playful curiosity. Start with your own lab. 🐧')
+    msg = make_message('can you teach me how to hack', user_id=20)
+    await skid.on_message(msg)
+    assert len(msg.replies) == 1
+    text, _ = msg.replies[0]
+    assert 'SKID DETECTOR' in text
+    assert '<@20>' in text
+    assert 'playful curiosity' in text
+    # The roaster saw the actual message
+    assert skid._roaster.calls[0][0] == 'can you teach me how to hack'
+
+
+async def test_llm_failure_falls_back_to_canned(skid):
+    skid.llm_enabled = True
+    skid._roaster = FakeRoaster(RuntimeError('model down'))
+    msg = make_message('teach me to hack', user_id=21)
+    await skid.on_message(msg)
+    assert len(msg.replies) == 1
+    text, _ = msg.replies[0]
+    assert 'SKID DETECTOR' in text and '<@21>' in text   # canned verdict
+
+
+async def test_llm_empty_reply_falls_back_to_canned(skid):
+    skid.llm_enabled = True
+    skid._roaster = FakeRoaster('   ')
+    msg = make_message('how do i ddos someone', user_id=22)
+    await skid.on_message(msg)
+    assert len(msg.replies) == 1
+    assert 'SKID DETECTOR' in msg.replies[0][0]
+
+
+async def test_llm_off_by_default(skid):
+    # The fixture sets no SKID_DETECTOR_LLM; the AI path must stay cold.
+    assert skid.llm_enabled is False
+    msg = make_message('teach me to hack', user_id=23)
+    await skid.on_message(msg)
+    assert len(msg.replies) == 1          # canned verdict, no AI import
+
+
+async def test_llm_long_roast_is_clamped(skid):
+    skid.llm_enabled = True
+    skid._roaster = FakeRoaster('x' * 2000)
+    msg = make_message('teach me to hack', user_id=24)
+    await skid.on_message(msg)
+    text, _ = msg.replies[0]
+    assert len(text) < 500


### PR DESCRIPTION
The detector's canned verdicts become the **fallback**; with `SKID_DETECTOR_LLM=true` the verdict body is generated per message by the roasting model (gemma4): a deadpan tease of the script-kiddie energy that **lands on encouragement** — hacking is tinkering and playful curiosity ("go hack the kitchen"), here's how to start for real.

### Live samples (gemma4:12b, from the box)

> **"can you teach me how to hack"**
> ⚠️ ALERT: Threat Level — "Downloaded Kali and renamed my desktop to 'Matrix'." … Hacking is just tinkering to see how systems work. Put down the how-to search bar and go build a lab; start by learning the docs and building something cool!

> **"i just downloaded kali im basically mr robot now"**
> ⚠️ ALERT: Script-Kiddie Signature Detected. Threat Level: "I just installed a tool and now I'm a cyber-god." Take a breath, Mr. Robot. Real hacking isn't about shiny tools; it's about curiosity…

### Guardrails in the prompt
- Tease the **trope**, never the person — no "kid"/belittling names, no gatekeeping, "you'll never be a hacker" banned.
- **NEVER** actual attack instructions, tool commands, or targets — redirecting the energy toward legal curiosity *is* the bit.

### Wiring
Mirrors `arch_banter`: lazy roaster init, canned-verdict fallback on AI off/down/empty output, 400-char clamp, same fire-chance + cooldowns. `SKID_DETECTOR_LLM` defaults **false** (repo convention: AI opt-in).

436 tests pass — new coverage: AI verdict path (header + mention + roast), exception fallback, empty-reply fallback, off-by-default, length clamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)