### PR TITLE
fix: greeter drops drive-by joiners and truly waits for the quarter hour

### DIFF
--- a/penguin-overlord/cogs/welcome_greeter.py
+++ b/penguin-overlord/cogs/welcome_greeter.py
@@ -154,6 +154,7 @@ class _GreetStage:
         # greetings land ON the boundary (:00/:15/:30/:45 for 900s), never
         # mid-window right after a boot.
         self._last_period = int(time.time() // self.cooldown)
+        self._queued_period = None           # window the pending batch started in
 
     # ------------------------------------------------------------ storage
 
@@ -180,6 +181,12 @@ class _GreetStage:
         whatever happens to the send, nobody is greeted twice."""
         self._welcomed.add(member.id)
         self._save()
+        if not self._pending:
+            # Remember which window this batch started in: it flushes at the
+            # first tick AFTER the next boundary, never mid-window (a quiet
+            # stretch used to leave _last_period stale, letting the first
+            # arrival of a fresh window fire within a minute of joining).
+            self._queued_period = int(time.time() // self.cooldown)
         self._pending.append(member)
 
     def mark_only(self, member_id: int):
@@ -230,17 +237,41 @@ class _GreetStage:
     # -------------------------------------------------------------- flush
 
     def due(self, now: float) -> bool:
-        """Members are waiting and the wall clock has crossed into a new
-        `cooldown`-aligned window since the last flush."""
+        """Members are waiting AND the wall clock has crossed a
+        `cooldown`-aligned boundary since both the last flush and the moment
+        the batch started queueing — greetings land ON :00/:15/:30/:45, at
+        most one per window."""
         if not self._pending:
             return False
-        return int(now // self.cooldown) > self._last_period
+        period = int(now // self.cooldown)
+        if self._queued_period is not None and period <= self._queued_period:
+            return False
+        return period > self._last_period
 
     async def _flush(self):
         if not self._pending:
             return
         members, self._pending = self._pending, []
+        self._queued_period = None
         self._last_period = int(time.time() // self.cooldown)
+
+        # Drive-by joins are real: a member who joined and LEFT before the
+        # window boundary renders as @unknown-user in the greeting. Greet
+        # only the people still here; if everyone bounced, say nothing.
+        still_here = []
+        for m in members:
+            guild = getattr(m, 'guild', None)
+            get_member = getattr(guild, 'get_member', None)
+            if callable(get_member) and get_member(m.id) is None:
+                continue
+            still_here.append(m)
+        if len(still_here) < len(members):
+            logger.info('%s welcome: %d member(s) left before the flush — '
+                        'dropped from the greeting', self.name,
+                        len(members) - len(still_here))
+        if not still_here:
+            return
+        members = still_here
 
         channel = self.bot.get_channel(self.channel_id)
         if channel is None:

--- a/penguin-overlord/cogs/welcome_greeter.py
+++ b/penguin-overlord/cogs/welcome_greeter.py
@@ -236,6 +236,29 @@ class _GreetStage:
 
     # -------------------------------------------------------------- flush
 
+    @staticmethod
+    async def _still_in_guild(m) -> bool:
+        """Whether a queued member is still resolvable in their guild.
+        Cache hit → yes. Cache miss → ask the API: a definitive NotFound
+        means they left (drop), anything inconclusive keeps them — a stale
+        cache must never cost a real member their welcome."""
+        guild = getattr(m, 'guild', None)
+        if guild is None:
+            return True
+        get_member = getattr(guild, 'get_member', None)
+        if not callable(get_member) or get_member(m.id) is not None:
+            return True
+        fetch = getattr(guild, 'fetch_member', None)
+        if not callable(fetch):
+            return True
+        try:
+            await fetch(m.id)
+            return True
+        except discord.NotFound:
+            return False
+        except discord.HTTPException:
+            return True              # can't tell — greet rather than ghost
+
     def due(self, now: float) -> bool:
         """Members are waiting AND the wall clock has crossed a
         `cooldown`-aligned boundary since both the last flush and the moment
@@ -258,13 +281,13 @@ class _GreetStage:
         # Drive-by joins are real: a member who joined and LEFT before the
         # window boundary renders as @unknown-user in the greeting. Greet
         # only the people still here; if everyone bounced, say nothing.
+        # A cache miss is NOT proof of departure — confirm with the API
+        # before dropping someone real from their own welcome, and keep
+        # them when the API can't say either way.
         still_here = []
         for m in members:
-            guild = getattr(m, 'guild', None)
-            get_member = getattr(guild, 'get_member', None)
-            if callable(get_member) and get_member(m.id) is None:
-                continue
-            still_here.append(m)
+            if await self._still_in_guild(m):
+                still_here.append(m)
         if len(still_here) < len(members):
             logger.info('%s welcome: %d member(s) left before the flush — '
                         'dropped from the greeting', self.name,

--- a/tests/unit/test_welcome_and_rules.py
+++ b/tests/unit/test_welcome_and_rules.py
@@ -257,6 +257,46 @@ async def test_flush_pins_the_stage_to_the_current_window(greeter):
     assert greeter.verify.due(now + 900) is True         # next window
 
 
+async def test_departed_members_are_not_greeted(greeter):
+    # Drive-by joins: someone who joined and LEFT before the window boundary
+    # renders as @unknown-user — drop them from the greeting instead.
+    here = member(31)
+    gone = member(32)
+    guild = types.SimpleNamespace(get_member=lambda uid: here if uid == 31 else None)
+    here.guild = guild
+    gone.guild = guild
+    greeter.join._pending = [here, gone]
+    await greeter.join._flush()
+    out = _in(greeter.sent, NEWBIES)
+    assert len(out) == 1
+    text, _ = out[0]
+    assert '<@31>' in text and '<@32>' not in text
+
+
+async def test_all_departed_means_silence(greeter):
+    gone = member(33)
+    gone.guild = types.SimpleNamespace(get_member=lambda uid: None)
+    greeter.join._pending = [gone]
+    await greeter.join._flush()
+    assert greeter.sent == []
+    # and the ghost stays marked so a rejoin isn't double-greeted... they
+    # were claimed at join time; the flush must not resurrect the pending.
+    assert greeter.join._pending == []
+
+
+async def test_fresh_batch_waits_for_the_next_boundary(greeter):
+    # Live bug: after a quiet window, _last_period was stale and the first
+    # arrival of a new window flushed at the very next 60s tick (17:31:51,
+    # 18:06:47 in the logs) instead of on the quarter hour. A batch must
+    # wait for the first boundary AFTER it started queueing.
+    import time as _time
+    greeter.join.claim(member(34))            # queued NOW, mid-window
+    now = _time.time()
+    assert greeter.join.due(now) is False     # same window as the queue
+    next_boundary = (int(now // 900) + 1) * 900
+    assert greeter.join.due(next_boundary + 1) is True
+
+
 async def test_boot_does_not_flush_mid_window(monkeypatch, tmp_path):
     # A fresh boot must wait for the next clock boundary, not greet whoever
     # queues within seconds of startup.

--- a/tests/unit/test_welcome_and_rules.py
+++ b/tests/unit/test_welcome_and_rules.py
@@ -257,12 +257,34 @@ async def test_flush_pins_the_stage_to_the_current_window(greeter):
     assert greeter.verify.due(now + 900) is True         # next window
 
 
+def _not_found():
+    import discord
+    return discord.NotFound(types.SimpleNamespace(status=404, reason='Not Found'),
+                            'Unknown Member')
+
+
+def _guild(present_ids, api_error=False):
+    """Fake guild: empty cache, so presence is decided by fetch_member —
+    the API either confirms, 404s, or (api_error) fails inconclusively."""
+    async def fetch_member(uid):
+        if api_error:
+            import discord
+            raise discord.HTTPException(
+                types.SimpleNamespace(status=500, reason='oops'), 'boom')
+        if uid in present_ids:
+            return member(uid)
+        raise _not_found()
+    return types.SimpleNamespace(get_member=lambda uid: None,
+                                 fetch_member=fetch_member)
+
+
 async def test_departed_members_are_not_greeted(greeter):
     # Drive-by joins: someone who joined and LEFT before the window boundary
-    # renders as @unknown-user — drop them from the greeting instead.
+    # renders as @unknown-user — drop them from the greeting instead. The
+    # cache misses both; the API confirms one and 404s the other.
     here = member(31)
     gone = member(32)
-    guild = types.SimpleNamespace(get_member=lambda uid: here if uid == 31 else None)
+    guild = _guild(present_ids={31})
     here.guild = guild
     gone.guild = guild
     greeter.join._pending = [here, gone]
@@ -275,13 +297,24 @@ async def test_departed_members_are_not_greeted(greeter):
 
 async def test_all_departed_means_silence(greeter):
     gone = member(33)
-    gone.guild = types.SimpleNamespace(get_member=lambda uid: None)
+    gone.guild = _guild(present_ids=set())
     greeter.join._pending = [gone]
     await greeter.join._flush()
     assert greeter.sent == []
     # and the ghost stays marked so a rejoin isn't double-greeted... they
     # were claimed at join time; the flush must not resurrect the pending.
     assert greeter.join._pending == []
+
+
+async def test_cache_miss_with_api_trouble_still_greets(greeter):
+    # A stale cache plus a flaky API must never cost a real member their
+    # welcome — inconclusive means greet.
+    maybe = member(35)
+    maybe.guild = _guild(present_ids=set(), api_error=True)
+    greeter.join._pending = [maybe]
+    await greeter.join._flush()
+    out = _in(greeter.sent, NEWBIES)
+    assert len(out) == 1 and '<@35>' in out[0][0]
 
 
 async def test_fresh_batch_waits_for_the_next_boundary(greeter):


### PR DESCRIPTION
Two greeter bugs the live deploy surfaced within hours of shipping:

## 1. `@unknown-user` in the Micro Center greeting

The logs identify the ghost: **poungui** joined 17:31 UTC, was greeted at 17:45 — and had already **left the server**. Discord renders a departed member's mention as `@unknown-user`. Drive-by joins are common (5 joins today, several bounced).

**Fix:** the flush greets only members still in the guild; if everyone in the batch bounced, it posts nothing at all.

## 2. Flushes weren't actually on the quarter hour

`join-welcomed` at **17:31:51, 18:06:47, 18:26:50** — not `:00/:15/:30/:45`. `due()` compared only against the *last flush* window, so after a quiet window the stale marker let the first arrival of a fresh window flush at the very next 60s tick. The once-per-window rate cap held; the alignment didn't.

**Fix:** a batch also waits for the first boundary *after it started queueing* — greetings now land on the quarter hour in all cases, including after quiet stretches and across boots.

439 tests pass; regression coverage for both (departed member dropped, all-departed silence, fresh-batch boundary wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)