### PR TITLE
fix: no more @unknown-user; profile screen holds the welcome and alerts mods

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,11 @@ by default** and the bot behaves exactly as before until you opt in.
 - **Newcomer helper** — optionally points brand-new members at your rules
   and resources channels when they ask where to start, with cooldowns and
   a false-positive-averse matcher ([guide](docs/features/NEWCOMER_HELPER.md))
+- **Profile screen** — usernames, display names and nicknames get the same
+  look messages do, at join and on every change; a flag holds the welcome
+  and posts a Ban / Kick / Dismiss card to the mod channel, and
+  `/profile sync-automod` mirrors the term list into a Discord AutoMod
+  member-profile rule so bios (which no bot can read) are covered too
 - **Privacy floor** — moderation inference never leaves your network (the
   remote fallback is hard-disabled for moderation in code), and nothing the
   bot posts to Discord ever contains an endpoint address: private hosts

--- a/docs/features/AI_MODERATION.md
+++ b/docs/features/AI_MODERATION.md
@@ -377,6 +377,47 @@ Data handling: only the first 300 characters of a flagged message are
 stored, purged after `MOD_RETENTION_DAYS` (90 default); `/mod purge_user`
 deletes everything stored about a user.
 
+### Profile screen (usernames, display names, nicknames, bios)
+
+Messages were scanned; names were not. A member arriving as "Aydolf hitler"
+got a warm greeting and the moderators found out when they found out. The
+profile screen runs every member's username, global display name, and
+server nickname through the same machinery at join and on every change:
+
+1. **Term screen** — the shared slur deny-list (leet and separator aware)
+   plus name-only terms that are fine in a sentence but not as a handle
+   (`hitler`, `nazi`, `swastika`, `pedo`, ...), plus staff impersonation
+   ("Discord Moderator", "Server Admin") and the guild owner's names.
+   Boundary rules keep `Nazim`, `Adolfo` and `kkkaty` clean.
+2. **Model second look** — names that pass the terms get one focused
+   question to the second-stage model (`PROFILE_SCREEN_LLM=true`). Only a
+   confident `hateful` or `impersonation` verdict flags; anything else is
+   silent, because an alert on every join is noise.
+3. **On a flag:** the welcome greeter **holds** that member (no warm
+   welcome until a moderator decides) and a 🪪 Profile alert lands in
+   `MOD_ALERT_CHANNEL_ID` with **Ban / Kick / Dismiss** buttons that
+   survive restarts. Dismiss releases the welcome; Ban and Kick act now.
+   The alert says which stage flagged it, so model-sourced flags can get
+   the extra scrutiny they deserve.
+
+**Bios are invisible to bots** (every bot, MEE6 included). Discord's own
+AutoMod can screen them through a member-profile keyword rule, so
+`/profile sync-automod` writes one from the same term lists: members whose
+username, display name, nickname, or bio matches are blocked from
+interacting until they change it. Run it once and again after editing the
+lists.
+
+```env
+PROFILE_SCREEN_ENABLED=true
+PROFILE_SCREEN_LLM=true                # default; needs the AI moderation setup
+PROFILE_SCREEN_HOLD_GREETING=true      # default
+PROFILE_SCREEN_PROTECTED_NAMES=        # extra impersonation targets, comma-separated
+```
+
+Operator name-only terms go in `data/profile_blocklist.txt` (one per line,
+`#` comments); `data/blocklist.txt` is honored too. `/profile status`
+shows the switches and the count of open flags.
+
 ## Graduating to enforcement (Phase 3 — not yet recommended)
 
 Only after ≥2 weeks of dry-run and `/mod stats` showing the precision you

--- a/penguin-overlord/cogs/profile_screen.py
+++ b/penguin-overlord/cogs/profile_screen.py
@@ -1,0 +1,512 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Profile Screen — usernames and display names get the same look messages do.
+
+A member who arrives as "Aydolf hitler" has told you everything before
+typing a word, yet nothing looked at the name: the greeter tagged it warmly
+and moderators found out when they found out. This cog screens every
+member's username, global display name, and server nickname at join and on
+every change, and when a name is unacceptable it:
+
+  1. HOLDS the welcome greeter for that member (no warm welcome until a
+     moderator decides), and
+  2. posts a Profile alert to the moderation alert channel with Ban / Kick /
+     Dismiss buttons. Dismiss releases the hold; Ban and Kick act at once.
+
+Screening is two-stage, cheap first:
+  - terms: the shared moderation deny-list (leetspeak- and separator-aware)
+    plus a short list of name-only terms (`hitler`, `nazi`, ...) that would
+    be ordinary in conversation but are not ordinary as a NAME, plus staff
+    and owner impersonation ("Discord Moderator", the owner's handle).
+  - model: names that pass the term screen get one focused question to the
+    local second-stage model (the same plumbing the newcomer helper uses).
+    Only a confident 'hateful' or 'impersonation' verdict flags; 'clean' or
+    an unavailable model stays quiet, because alerting on every join is
+    noise, not moderation.
+
+What bots cannot see: the "About Me" bio. Discord exposes it to no bot, MEE6
+included. Discord's own AutoMod CAN screen it through a member-profile
+keyword rule, and `/profile sync-automod` writes one from the same term
+lists, so bios are covered without a second word list to maintain.
+
+Configuration:
+    PROFILE_SCREEN_ENABLED=false      master switch
+    PROFILE_SCREEN_LLM=true           ask the second-stage model after the
+                                      term screen (needs AI moderation set up)
+    PROFILE_SCREEN_HOLD_GREETING=true park the welcome while a flag is open
+    PROFILE_SCREEN_PROTECTED_NAMES=   extra impersonation targets, comma
+                                      separated (the owner's names are
+                                      always protected)
+    MOD_ALERT_CHANNEL_ID=             reused: where Profile alerts go
+    MOD_PING_ROLE_ID=                 reused: role pinged on an alert
+    data/profile_blocklist.txt        optional operator name-only terms,
+                                      one per line, # comments
+"""
+
+import logging
+import os
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from ai.guardrails import _DENY_TERMS, _load_operator_blocklist, find_blocked_terms, strip_invisible
+from utils.state import resolve_data_dir
+
+logger = logging.getLogger(__name__)
+
+# Fine in a sentence, not fine as a name. Matched with the deny-list's
+# boundary rules, so 'Nazim' and 'Adolfo' pass while 'heil hitler' does not.
+NAME_TERMS = (
+    'hitler', 'adolf', 'nazi', 'nazis', 'heil', 'sieg heil', 'kkk', 'klansman',
+    'himmler', 'goebbels', 'mengele', 'swastika', 'gas the jews', 'jew killer',
+    'rapist', 'pedo', 'pedophile', 'paedophile', 'child lover', 'lolicon',
+    'school shooter', 'mass shooter',
+)
+
+# Whole-word staff claims. 'mod' and 'admin' alone hit too many gamer tags;
+# these do not.
+_IMPERSONATION = (
+    'moderator', 'administrator', 'discord staff', 'discord support',
+    'discord admin', 'discord mod', 'server admin', 'server owner',
+    'official discord', 'system message',
+)
+
+PROFILE_PROMPT = """You screen Discord profile names for a friendly hacker community. You are
+given a member's username, display name, and nickname. Decide whether the
+NAMES THEMSELVES are unacceptable:
+
+- hateful: slurs; references to genocide or its perpetrators (Hitler, Nazi
+  imagery, 1488, 88 paired with white-power cues); dehumanizing content about
+  a protected group; glorifying mass violence or child abuse. This includes
+  leetspeak, spacing tricks, and deliberate misspellings meant to slip past a
+  filter (e.g. "Aydolf", "h1tl3r", "n1gg4").
+- impersonation: claims to be Discord staff, a moderator or administrator of
+  this server, or a specific known person here.
+- clean: everything else. Edgy jokes, gamer tags, foreign words, and names
+  that merely CONTAIN a bad substring by accident (Nazim, Adolfo, kkkaty,
+  Scunthorpe) are clean. When in doubt, clean.
+
+Respond with exactly one line and nothing else:
+VERDICT: hateful | impersonation | clean"""
+
+_PROFILE_VERDICTS = frozenset({'hateful', 'impersonation', 'clean'})
+
+_COLORS = {'hate_speech': 0xD32F2F, 'impersonation': 0xF57C00}
+
+
+@dataclass
+class ProfileVerdict:
+    category: str            # hate_speech | impersonation
+    reason: str
+    source: str              # denylist | model
+
+
+def _env(name: str, default: str = '') -> str:
+    return os.getenv(name, default)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+def _load_profile_blocklist() -> tuple:
+    path = Path(resolve_data_dir()) / 'profile_blocklist.txt'
+    try:
+        if path.exists():
+            return tuple(
+                line.strip().lower()
+                for line in path.read_text(encoding='utf-8').splitlines()
+                if line.strip() and not line.strip().startswith('#'))
+    except OSError:
+        pass
+    return ()
+
+
+def _name_terms() -> tuple:
+    return NAME_TERMS + _load_operator_blocklist() + _load_profile_blocklist()
+
+
+def _plain(name: str) -> str:
+    """Lowercase, separators to spaces, for whole-word impersonation checks."""
+    name = strip_invisible(name or '').lower()
+    return re.sub(r'[\W_]+', ' ', name).strip()
+
+
+def screen_terms(names: list, protected: tuple = ()) -> ProfileVerdict | None:
+    """The cheap stage: deny-list + name-only terms + impersonation. Pure."""
+    for name in names:
+        hits = find_blocked_terms(name, extra_terms=_name_terms())
+        if hits:
+            return ProfileVerdict('hate_speech',
+                                  f'name "{name}" matches: {", ".join(hits)}',
+                                  'denylist')
+    for name in names:
+        plain = _plain(name)
+        for term in _IMPERSONATION:
+            if re.search(rf'\b{re.escape(term)}\b', plain):
+                return ProfileVerdict('impersonation',
+                                      f'name "{name}" claims "{term}"',
+                                      'denylist')
+        squashed = plain.replace(' ', '')
+        for target in protected:
+            t = _plain(target).replace(' ', '')
+            if t and t in squashed:
+                return ProfileVerdict('impersonation',
+                                      f'name "{name}" imitates "{target}"',
+                                      'denylist')
+    return None
+
+
+def automod_keywords() -> list:
+    """Keyword list for Discord's member-profile AutoMod rule: the same terms
+    this cog screens with, within Discord's limits (1000 words, 60 chars)."""
+    seen = []
+    for term in list(_DENY_TERMS) + list(_name_terms()):
+        term = term.strip().lower()
+        if term and len(term) <= 60 and term not in seen:
+            seen.append(term)
+    return seen[:1000]
+
+
+AUTOMOD_RULE_NAME = 'Penguin Overlord: profile screen'
+
+
+class ProfileButton(discord.ui.DynamicItem[discord.ui.Button],
+                    template=r'profile:(?P<verb>ban|kick|dismiss):(?P<user_id>[0-9]+)'):
+    """Persistent alert button: the target lives in the custom_id, so it
+    survives restarts like the moderation review buttons."""
+
+    _STYLE = {'ban': discord.ButtonStyle.danger,
+              'kick': discord.ButtonStyle.primary,
+              'dismiss': discord.ButtonStyle.secondary}
+
+    def __init__(self, verb: str, user_id: int):
+        super().__init__(discord.ui.Button(
+            style=self._STYLE[verb], label=verb.title(),
+            custom_id=f'profile:{verb}:{user_id}'))
+        self.verb = verb
+        self.user_id = user_id
+
+    @property
+    def label(self) -> str:
+        return self.item.label
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match):
+        return cls(match['verb'], int(match['user_id']))
+
+    async def callback(self, interaction: discord.Interaction):
+        logger.info('Profile button %s:%s clicked by %s',
+                    self.verb, self.user_id, interaction.user)
+        perms = interaction.user.guild_permissions
+        allowed = {'ban': perms.ban_members, 'kick': perms.kick_members,
+                   'dismiss': perms.kick_members or perms.manage_messages}
+        if not allowed[self.verb]:
+            await interaction.response.send_message(
+                f'You need permission to {self.verb} members for that.',
+                ephemeral=True)
+            return
+        cog = interaction.client.get_cog('ProfileScreen')
+        if cog is None:
+            await interaction.response.send_message(
+                'Profile screen cog is not loaded.', ephemeral=True)
+            return
+        outcome = await cog.resolve(interaction.guild, self.user_id,
+                                    self.verb, moderator=str(interaction.user))
+        embed = None
+        if interaction.message and interaction.message.embeds:
+            embed = interaction.message.embeds[0]
+            embed.set_footer(text=f'Resolved: {outcome}')
+        await interaction.response.edit_message(embed=embed, view=None)
+
+
+class ProfileScreen(commands.Cog):
+    """Screen names at join and on change; hold the welcome; alert mods."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.enabled = _env_bool('PROFILE_SCREEN_ENABLED', False)
+        self.use_model = _env_bool('PROFILE_SCREEN_LLM', True)
+        self.hold_greeting = _env_bool('PROFILE_SCREEN_HOLD_GREETING', True)
+        alert = _env('MOD_ALERT_CHANNEL_ID')
+        self.alert_channel_id = int(alert) if alert.isdigit() else None
+        ping = _env('MOD_PING_ROLE_ID')
+        self.ping_role_id = int(ping) if ping.isdigit() else None
+        self.protected = tuple(
+            t.strip() for t in _env('PROFILE_SCREEN_PROTECTED_NAMES').split(',')
+            if t.strip())
+        self.analyzer = None
+        self._alerted: dict = {}       # user_id -> frozenset(names) alerted on
+        self._open: dict = {}          # user_id -> ProfileVerdict awaiting a mod
+
+        if self.enabled and self.alert_channel_id is None:
+            logger.error('PROFILE_SCREEN_ENABLED=true but MOD_ALERT_CHANNEL_ID '
+                         'is not set; profile screen stays off')
+            self.enabled = False
+
+    async def cog_load(self):
+        self.bot.add_dynamic_items(ProfileButton)
+        if not self.enabled:
+            return
+        if self.use_model:
+            try:
+                from ai.manager import get_ai_manager
+                from ai.features.moderation import ModerationAnalyzer
+                self.analyzer = ModerationAnalyzer(await get_ai_manager())
+            except Exception as e:
+                logger.error('Profile screen model stage unavailable, terms '
+                             'only: %s', type(e).__name__)
+        logger.info('Profile screen active: model=%s, hold greeting=%s, '
+                    'alerts -> %s', self.analyzer is not None,
+                    self.hold_greeting, self.alert_channel_id)
+
+    # ------------------------------------------------------------ screening
+
+    @staticmethod
+    def _names(member) -> list:
+        names = []
+        for attr in ('name', 'global_name', 'nick'):
+            value = getattr(member, attr, None)
+            if value and value not in names:
+                names.append(value)
+        return names
+
+    def _protected_for(self, member) -> tuple:
+        owner = getattr(getattr(member, 'guild', None), 'owner', None)
+        extra = tuple(
+            v for v in (getattr(owner, 'name', None),
+                        getattr(owner, 'display_name', None)) if v)
+        return self.protected + extra
+
+    async def screen(self, member) -> ProfileVerdict | None:
+        names = self._names(member)
+        if not names:
+            return None
+        verdict = screen_terms(names, protected=self._protected_for(member))
+        if verdict is not None:
+            return verdict
+        if self.analyzer is None:
+            return None
+        content = ' / '.join(f'{label}: {value}' for label, value in (
+            ('username', getattr(member, 'name', None)),
+            ('display name', getattr(member, 'global_name', None)),
+            ('nickname', getattr(member, 'nick', None))) if value)
+        try:
+            answer = await self.analyzer.adjudicate_custom(
+                PROFILE_PROMPT, content, str(member),
+                allowed=_PROFILE_VERDICTS, kind='profile')
+        except Exception as e:
+            logger.warning('Profile model check failed: %s', type(e).__name__)
+            return None
+        if answer == 'hateful':
+            return ProfileVerdict('hate_speech',
+                                  'second-stage model judged the name hateful',
+                                  'model')
+        if answer == 'impersonation':
+            return ProfileVerdict('impersonation',
+                                  'second-stage model judged the name an '
+                                  'impersonation', 'model')
+        return None
+
+    async def _check(self, member, trigger: str):
+        if not self.enabled or getattr(member, 'bot', False):
+            return
+        owner = getattr(getattr(member, 'guild', None), 'owner', None)
+        if owner is not None and getattr(owner, 'id', None) == member.id:
+            return
+        names = frozenset(self._names(member))
+        if self._alerted.get(member.id) == names:
+            return
+        verdict = await self.screen(member)
+        if verdict is None:
+            return
+        self._alerted[member.id] = names
+        if len(self._alerted) > 5000:
+            self._alerted.clear()
+        await self._flag(member, verdict, trigger)
+
+    async def _flag(self, member, verdict: ProfileVerdict, trigger: str):
+        self._open[member.id] = verdict
+        if self.hold_greeting:
+            greeter = self.bot.get_cog('WelcomeGreeter')
+            if greeter is not None:
+                greeter.hold(member.id)
+        logger.warning('Profile flag (%s, %s) on %s at %s: %s', verdict.category,
+                       verdict.source, member, trigger, verdict.reason)
+
+        channel = self.bot.get_channel(self.alert_channel_id)
+        if channel is None:
+            logger.error('Alert channel %s not found', self.alert_channel_id)
+            return
+
+        names = ' · '.join(self._names(member))
+        lines = [
+            f'**User:** {member.mention} ({member})',
+            f'**Names:** {names}',
+            f'**Trigger:** {trigger}',
+        ]
+        created = getattr(member, 'created_at', None)
+        if created is not None:
+            age = (discord.utils.utcnow() - created).days
+            lines.append(f'**Account age:** {age} day{"s" if age != 1 else ""}')
+        lines.append(f'**Reason:** {verdict.reason}')
+        lines.append(f'**Source:** {verdict.source}'
+                     + (' (model call, scrutinize)' if verdict.source == 'model' else ''))
+        embed = discord.Embed(
+            title=f"🪪 Profile flag: {verdict.category.replace('_', ' ').title()}",
+            description='\n'.join(lines),
+            color=_COLORS.get(verdict.category, 0x9E9E9E))
+        embed.set_footer(text='Ban / Kick act now. Dismiss releases their welcome.')
+
+        view = discord.ui.View(timeout=None)
+        for verb in ('ban', 'kick', 'dismiss'):
+            view.add_item(ProfileButton(verb, member.id))
+
+        content = None
+        allowed = None
+        if self.ping_role_id:
+            content = f'<@&{self.ping_role_id}>'
+            allowed = discord.AllowedMentions(
+                everyone=False, users=False,
+                roles=[discord.Object(id=self.ping_role_id)])
+        try:
+            await channel.send(content=content, embed=embed, view=view,
+                               allowed_mentions=allowed)
+        except discord.HTTPException:
+            logger.exception('Could not post the profile alert')
+
+    # ------------------------------------------------------------- resolve
+
+    async def resolve(self, guild, user_id: int, verb: str, moderator: str) -> str:
+        """Carry out a moderator's button choice; returns a short outcome
+        for the alert footer. Always releases the greeting hold: after a
+        ban there is nobody to greet, after a dismiss they are welcome."""
+        self._open.pop(user_id, None)
+        greeter = self.bot.get_cog('WelcomeGreeter')
+        if greeter is not None:
+            greeter.release(user_id)
+        reason = f'Profile screen: {verb} by {moderator}'
+
+        if verb == 'dismiss':
+            return f'dismissed by {moderator}'
+
+        member = None
+        get_member = getattr(guild, 'get_member', None)
+        if callable(get_member):
+            member = get_member(user_id)
+        if member is None and callable(getattr(guild, 'fetch_member', None)):
+            try:
+                member = await guild.fetch_member(user_id)
+            except discord.NotFound:
+                member = None
+            except discord.HTTPException:
+                return f'{verb} failed (Discord error), by {moderator}'
+
+        try:
+            if verb == 'kick':
+                if member is None:
+                    return f'kick: already left, by {moderator}'
+                await member.kick(reason=reason)
+                return f'kicked by {moderator}'
+            if member is not None:
+                await member.ban(reason=reason, delete_message_days=1)
+            else:
+                await guild.ban(discord.Object(id=user_id), reason=reason,
+                                delete_message_days=1)
+            return f'banned by {moderator}'
+        except discord.Forbidden:
+            return f'{verb} failed (missing permission), by {moderator}'
+        except discord.HTTPException:
+            return f'{verb} failed (Discord error), by {moderator}'
+
+    # -------------------------------------------------------------- events
+
+    @commands.Cog.listener()
+    async def on_member_join(self, member: discord.Member):
+        await self._check(member, 'join')
+
+    @commands.Cog.listener()
+    async def on_member_update(self, before: discord.Member, after: discord.Member):
+        if self._names(before) == self._names(after):
+            return
+        await self._check(after, 'name change')
+
+    @commands.Cog.listener()
+    async def on_user_update(self, before: discord.User, after: discord.User):
+        # Username / global display name changes arrive as user updates.
+        if (before.name, before.global_name) == (after.name, after.global_name):
+            return
+        for guild in getattr(self.bot, 'guilds', []):
+            member = guild.get_member(after.id)
+            if member is not None:
+                await self._check(member, 'name change')
+
+    # ------------------------------------------------------------ commands
+
+    profile = app_commands.Group(
+        name='profile', description='Profile screening (owner tools)',
+        default_permissions=discord.Permissions(administrator=True))
+
+    @profile.command(name='status', description='Profile screen status')
+    async def profile_status(self, interaction: discord.Interaction):
+        await interaction.response.send_message(
+            f'Profile screen: {"on" if self.enabled else "off"}, '
+            f'model stage: {"on" if self.analyzer else "off"}, '
+            f'open flags: {len(self._open)}, '
+            f'name terms: {len(_name_terms())}, '
+            f'AutoMod keywords: {len(automod_keywords())}',
+            ephemeral=True)
+
+    @profile.command(name='sync-automod',
+                     description='Write the name terms into a Discord AutoMod '
+                                 'member-profile rule (covers bios)')
+    async def profile_sync_automod(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=True)
+        guild = interaction.guild
+        trigger = discord.AutoModTrigger(keyword_filter=automod_keywords())
+        actions = [discord.AutoModRuleAction(
+            type=discord.AutoModRuleActionType.block_member_interactions)]
+        try:
+            existing = [r for r in await guild.fetch_automod_rules()
+                        if r.name == AUTOMOD_RULE_NAME]
+            if existing:
+                await existing[0].edit(trigger=trigger, actions=actions,
+                                       enabled=True,
+                                       reason='Profile screen sync')
+                what = 'updated'
+            else:
+                await guild.create_automod_rule(
+                    name=AUTOMOD_RULE_NAME,
+                    event_type=discord.AutoModRuleEventType.member_update,
+                    trigger=trigger, actions=actions, enabled=True,
+                    reason='Profile screen sync')
+                what = 'created'
+        except discord.Forbidden:
+            await interaction.followup.send(
+                'I need the Manage Server permission to manage AutoMod rules.',
+                ephemeral=True)
+            return
+        except discord.HTTPException as e:
+            await interaction.followup.send(
+                f'AutoMod rule sync failed: {e.text or type(e).__name__}',
+                ephemeral=True)
+            return
+        await interaction.followup.send(
+            f'AutoMod member-profile rule {what} with '
+            f'{len(trigger.keyword_filter)} keywords. Members whose username, '
+            f'display name, nickname, or bio matches are blocked from '
+            f'interacting until they change it.', ephemeral=True)
+
+
+async def setup(bot):
+    await bot.add_cog(ProfileScreen(bot))
+    logger.info('ProfileScreen cog loaded')

--- a/penguin-overlord/cogs/welcome_greeter.py
+++ b/penguin-overlord/cogs/welcome_greeter.py
@@ -36,6 +36,13 @@ churn or a re-join never produces a duplicate. The verify stage also gates
 on tenure: a veteran who only now picks up the reaction role is not a new
 arrival and is quietly marked instead of greeted.
 
+A greeting is also cleaned up after the fact: when a member leaves or is
+banned within WELCOME_RETRACT_WINDOW_SECONDS of being welcomed, the bot
+edits them out of the greeting (or deletes it if they were the only one).
+Discord clients render a departed user's mention as @unknown-user however
+the message was sent, and a troll banned for their display name should not
+keep a warm welcome on the wall either.
+
 Every timer here is environment-tunable; nothing is hardcoded. Each stage
 schedules one of two ways:
   - interval windows: WELCOME_<STAGE>_COOLDOWN_SECONDS, aligned to the wall
@@ -48,6 +55,8 @@ Configuration:
     WELCOME_ENABLED=false            master switch for both stages
     WELCOME_MAX_MENTIONS=12          mention this many; the rest are a count
     WELCOME_TIMEZONE=UTC             IANA timezone for the DAILY_AT schedules
+    WELCOME_RETRACT_WINDOW_SECONDS=86400  edit a leaver out of a greeting
+                                     this recent; older ones are history
 
   Shared channel references (used in message placeholders):
     WELCOME_RULES_CHANNEL_ID=        {rules}
@@ -210,7 +219,8 @@ class _GreetStage:
     def __init__(self, bot, *, name, enabled, channel_id, template,
                  default_template, image_path, cooldown, max_mentions,
                  welcomed_file, refs, max_tenure_days=0.0, min_wait=0.0,
-                 skip_role_id=None, daily_at=None, tz=None):
+                 skip_role_id=None, daily_at=None, tz=None,
+                 retract_window=86400.0):
         self.bot = bot
         self.name = name
         self.enabled = enabled
@@ -229,6 +239,13 @@ class _GreetStage:
         self.tz = tz
         self._welcomed = self._load()
         self._pending: list = []             # [(member, ready_at wall time)]
+        # Greetings we posted recently: [(message, [members], sent_at)].
+        # Kept so a member who LEAVES right after being welcomed (drive-by,
+        # or banned for the name they showed up with) can be edited out —
+        # Discord clients render a departed user's mention as @unknown-user
+        # no matter how the message was sent, so the fix is after the fact.
+        self._posted: list = []
+        self.retract_window = retract_window # seconds a greeting stays editable
         # The window we last flushed in (or booted in): members go out at
         # the first tick after the boundary FOLLOWING their ready time, so
         # greetings land ON the boundary — :00/:15/:30/:45 for a 900s
@@ -411,12 +428,10 @@ class _GreetStage:
                 logger.warning('%s welcome image %s unreadable — sending text '
                                'only', self.name, self.image_path)
         try:
-            await channel.send(
+            posted = await channel.send(
                 self.render(members),
                 file=attachment,
-                allowed_mentions=discord.AllowedMentions(
-                    everyone=False, roles=False,
-                    users=members[:self.max_mentions]),
+                allowed_mentions=self._mentions(members),
             )
         except discord.HTTPException:
             logger.exception('Could not send the %s welcome message', self.name)
@@ -424,6 +439,46 @@ class _GreetStage:
 
         logger.info('%s-welcomed %d member(s): %s', self.name, len(members),
                     ', '.join(str(m) for m in members[:5]))
+        if posted is not None:
+            self._posted.append((posted, list(members), now))
+            self._posted = self._posted[-200:]
+
+    def _mentions(self, members: list) -> discord.AllowedMentions:
+        return discord.AllowedMentions(everyone=False, roles=False,
+                                       users=members[:self.max_mentions])
+
+    # ------------------------------------------------------------ retract
+
+    async def retract(self, member_id: int, now: float = None):
+        """Edit a recently posted greeting so it no longer names a member
+        who has since left; delete it when they were the only one. Older
+        greetings are history and stay as they are."""
+        if now is None:
+            now = time.time()
+        self._posted = [(msg, ms, at) for msg, ms, at in self._posted
+                        if now - at <= self.retract_window]
+        kept = []
+        for msg, members, at in self._posted:
+            if all(m.id != member_id for m in members):
+                kept.append((msg, members, at))
+                continue
+            remaining = [m for m in members if m.id != member_id]
+            try:
+                if remaining:
+                    await msg.edit(content=self.render(remaining),
+                                   allowed_mentions=self._mentions(remaining))
+                    kept.append((msg, remaining, at))
+                else:
+                    await msg.delete()
+            except discord.HTTPException:
+                logger.warning('Could not retract member %s from a %s '
+                               'greeting (harmless)', member_id, self.name)
+                kept.append((msg, remaining, at))
+            else:
+                logger.info('%s welcome: member %s left, greeting %s',
+                            self.name, member_id,
+                            'edited' if remaining else 'removed')
+        self._posted = kept
 
 
 class WelcomeGreeter(commands.Cog):
@@ -445,6 +500,7 @@ class WelcomeGreeter(commands.Cog):
         }
         self.role_id = _env_id('WELCOME_ROLE_ID')
         tz = _env_tz('WELCOME_TIMEZONE')
+        retract_window = float(_env('WELCOME_RETRACT_WINDOW_SECONDS', '86400'))
 
         self.join = _GreetStage(
             bot, name='join',
@@ -464,6 +520,7 @@ class WelcomeGreeter(commands.Cog):
             skip_role_id=self.role_id,
             daily_at=_env_time('WELCOME_JOIN_DAILY_AT'),
             tz=tz,
+            retract_window=retract_window,
         )
         self.verify = _GreetStage(
             bot, name='verify',
@@ -481,6 +538,7 @@ class WelcomeGreeter(commands.Cog):
             max_tenure_days=float(_env('WELCOME_MAX_TENURE_DAYS', '30')),
             daily_at=_env_time('WELCOME_VERIFY_DAILY_AT'),
             tz=tz,
+            retract_window=retract_window,
         )
 
         # Validation: a stage missing its channel (or the verify role) is a
@@ -562,6 +620,17 @@ class WelcomeGreeter(commands.Cog):
         self.verify.claim(after)
         logger.info('Verify welcome queued for %s (%d pending)',
                     after, len(self.verify._pending))
+
+    @commands.Cog.listener()
+    async def on_member_remove(self, member: discord.Member):
+        """Leaving (or being banned) shortly after a welcome pulls the
+        member back out of it; a ban also fires this event."""
+        for stage in (self.join, self.verify):
+            if stage.enabled:
+                try:
+                    await stage.retract(member.id)
+                except Exception:
+                    logger.exception('%s welcome retraction failed', stage.name)
 
     @tasks.loop(seconds=60)
     async def greet_tick(self):

--- a/penguin-overlord/cogs/welcome_greeter.py
+++ b/penguin-overlord/cogs/welcome_greeter.py
@@ -246,6 +246,9 @@ class _GreetStage:
         # no matter how the message was sent, so the fix is after the fact.
         self._posted: list = []
         self.retract_window = retract_window # seconds a greeting stays editable
+        # Member ids parked by the profile screener (a flagged display
+        # name): they stay pending, unmentioned, until a moderator decides.
+        self.held: set = set()
         # The window we last flushed in (or booted in): members go out at
         # the first tick after the boundary FOLLOWING their ready time, so
         # greetings land ON the boundary — :00/:15/:30/:45 for a 900s
@@ -382,10 +385,12 @@ class _GreetStage:
         stay queued for a later window."""
         if now is None:
             now = time.time()
-        ripe = [(m, r) for m, r in self._pending if r <= now]
+        ripe = [(m, r) for m, r in self._pending
+                if r <= now and m.id not in self.held]
         if not ripe:
             return
-        self._pending = [(m, r) for m, r in self._pending if r > now]
+        self._pending = [(m, r) for m, r in self._pending
+                         if r > now or m.id in self.held]
         self._last_period = self._period(now)
         members = [m for m, _ in ripe]
 
@@ -621,11 +626,26 @@ class WelcomeGreeter(commands.Cog):
         logger.info('Verify welcome queued for %s (%d pending)',
                     after, len(self.verify._pending))
 
+    # ------------------------------------------------------------- holds
+
+    def hold(self, member_id: int):
+        """Park a member (flagged profile): no stage greets them until
+        `release`. Called by the profile screener."""
+        for stage in (self.join, self.verify):
+            stage.held.add(member_id)
+
+    def release(self, member_id: int):
+        for stage in (self.join, self.verify):
+            stage.held.discard(member_id)
+
     @commands.Cog.listener()
     async def on_member_remove(self, member: discord.Member):
         """Leaving (or being banned) shortly after a welcome pulls the
         member back out of it; a ban also fires this event."""
         for stage in (self.join, self.verify):
+            stage.held.discard(member.id)
+            stage._pending = [(m, r) for m, r in stage._pending
+                              if m.id != member.id]
             if stage.enabled:
                 try:
                     await stage.retract(member.id)

--- a/tests/unit/test_profile_screen.py
+++ b/tests/unit/test_profile_screen.py
@@ -1,0 +1,261 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Profile screener: usernames and display names get the same look messages
+do, and a flag holds the welcome and alerts the mod channel."""
+
+import types
+
+import pytest
+
+from cogs import profile_screen as ps
+from cogs.profile_screen import ProfileScreen
+
+ALERTS = 555
+OWNER_ID = 7
+
+
+def _member(user_id=42, name='cooluser', global_name=None, nick=None,
+            bot=False, guild=None):
+    m = types.SimpleNamespace(
+        id=user_id, name=name, global_name=global_name, nick=nick, bot=bot,
+        display_name=nick or global_name or name, mention=f'<@{user_id}>',
+        guild=guild or _guild(),
+        created_at=None, joined_at=None,
+        banned=[], kicked=[],
+    )
+    m.__str__ = lambda self: self.name
+
+    async def ban(reason=None, **kw):
+        m.banned.append(reason)
+
+    async def kick(reason=None):
+        m.kicked.append(reason)
+    m.ban = ban
+    m.kick = kick
+    return m
+
+
+def _guild():
+    return types.SimpleNamespace(
+        id=1, owner=types.SimpleNamespace(id=OWNER_ID, name='chiefgyk3d',
+                                          display_name='ChiefGyk3D'))
+
+
+class _Analyzer:
+    """Stand-in second stage: answers what it is told to, records the ask."""
+
+    def __init__(self, verdict='clean'):
+        self.verdict = verdict
+        self.calls = []
+
+    async def adjudicate_custom(self, system_prompt, content, username, *,
+                                allowed, kind='custom', context_messages=None,
+                                note=None):
+        self.calls.append((content, kind))
+        return self.verdict
+
+
+class _Channel:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, content=None, **kw):
+        self.sent.append((content, kw))
+        return types.SimpleNamespace(id=900 + len(self.sent), edit=self._edit)
+
+    async def _edit(self, **kw):
+        pass
+
+
+class _Greeter:
+    def __init__(self):
+        self.held = []
+        self.released = []
+
+    def hold(self, uid):
+        self.held.append(uid)
+
+    def release(self, uid):
+        self.released.append(uid)
+
+
+@pytest.fixture
+def cog(monkeypatch):
+    monkeypatch.setenv('PROFILE_SCREEN_ENABLED', 'true')
+    monkeypatch.setenv('MOD_ALERT_CHANNEL_ID', str(ALERTS))
+    monkeypatch.setenv('MOD_PING_ROLE_ID', '777')
+    monkeypatch.delenv('PROFILE_SCREEN_PROTECTED_NAMES', raising=False)
+    channel = _Channel()
+    greeter = _Greeter()
+    bot = types.SimpleNamespace(
+        get_channel=lambda cid: channel if cid == ALERTS else None,
+        get_cog=lambda name: greeter if name == 'WelcomeGreeter' else None,
+    )
+    c = ProfileScreen(bot)
+    c.analyzer = _Analyzer()
+    c.channel = channel
+    c.greeter = greeter
+    return c
+
+
+# -- the pure term screen ----------------------------------------------------
+
+def test_slur_in_username_is_flagged_by_denylist():
+    v = ps.screen_terms(['n1gg4_king'])
+    assert v is not None
+    assert v.category == 'hate_speech' and v.source == 'denylist'
+
+
+def test_hitler_display_name_is_flagged():
+    v = ps.screen_terms(['me_killed_him_97629', 'Aydolf hitler'])
+    assert v is not None and v.category == 'hate_speech'
+    assert 'hitler' in v.reason
+
+
+def test_staff_impersonation_is_flagged():
+    v = ps.screen_terms(['Discord Moderator'])
+    assert v is not None and v.category == 'impersonation'
+
+
+def test_owner_impersonation_is_flagged():
+    v = ps.screen_terms(['ChiefGyk3D_'], protected=('chiefgyk3d',))
+    assert v is not None and v.category == 'impersonation'
+
+
+def test_ordinary_names_pass_the_term_screen():
+    for name in ('hidadiya', 'thesaltynewfie', 'admiral_ackbar', 'Nazim',
+                 'Adolfo', 'kkkaty'):
+        assert ps.screen_terms([name]) is None, name
+
+
+# -- the model second look -----------------------------------------------------
+
+async def test_clean_name_asks_the_model_and_stays_quiet(cog):
+    verdict = await cog.screen(_member(name='cooluser'))
+    assert verdict is None
+    assert len(cog.analyzer.calls) == 1
+    content, kind = cog.analyzer.calls[0]
+    assert 'cooluser' in content and kind == 'profile'
+
+
+async def test_model_verdict_hateful_flags(cog):
+    cog.analyzer = _Analyzer('hateful')
+    # A name the term screen cannot catch (no listed term), so the model
+    # is the only stage that can flag it.
+    verdict = await cog.screen(_member(name='gas_chamber_enjoyer'))
+    assert verdict is not None
+    assert verdict.category == 'hate_speech' and verdict.source == 'model'
+
+
+async def test_model_uncertain_is_not_a_flag(cog):
+    cog.analyzer = _Analyzer('uncertain')
+    assert await cog.screen(_member(name='whatever')) is None
+
+
+async def test_term_hit_skips_the_model(cog):
+    verdict = await cog.screen(_member(name='Aydolf hitler'))
+    assert verdict is not None and verdict.source == 'denylist'
+    assert cog.analyzer.calls == []
+
+
+async def test_all_names_are_screened(cog):
+    m = _member(name='fine', global_name='also fine', nick='heil hitler')
+    verdict = await cog.screen(m)
+    assert verdict is not None and 'hitler' in verdict.reason
+
+
+# -- the cog: alert + hold -----------------------------------------------------
+
+async def test_join_with_a_flagged_name_alerts_and_holds(cog):
+    m = _member(user_id=42, name='Aydolf hitler')
+    await cog.on_member_join(m)
+
+    assert cog.greeter.held == [42]
+    assert len(cog.channel.sent) == 1
+    content, kw = cog.channel.sent[0]
+    assert content == '<@&777>'
+    embed = kw['embed']
+    assert 'Profile' in embed.title
+    assert '<@42>' in embed.description and 'hitler' in embed.description
+    labels = [item.label for item in kw['view'].children]
+    assert labels == ['Ban', 'Kick', 'Dismiss']
+
+
+async def test_clean_join_is_silent(cog):
+    await cog.on_member_join(_member(name='cooluser'))
+    assert cog.channel.sent == [] and cog.greeter.held == []
+
+
+async def test_bots_are_ignored(cog):
+    await cog.on_member_join(_member(name='hitler bot', bot=True))
+    assert cog.channel.sent == []
+
+
+async def test_nickname_change_is_rescreened(cog):
+    before = _member(user_id=43, name='fine')
+    after = _member(user_id=43, name='fine', nick='Aydolf hitler')
+    await cog.on_member_update(before, after)
+    assert len(cog.channel.sent) == 1 and cog.greeter.held == [43]
+
+
+async def test_unrelated_member_update_is_not_rescreened(cog):
+    cog.analyzer = _Analyzer('hateful')
+    before = _member(user_id=44, name='fine')
+    after = _member(user_id=44, name='fine')
+    await cog.on_member_update(before, after)
+    assert cog.channel.sent == [] and cog.analyzer.calls == []
+
+
+async def test_same_member_is_not_alerted_twice_for_the_same_names(cog):
+    m = _member(user_id=45, name='Aydolf hitler')
+    await cog.on_member_join(m)
+    await cog.on_member_update(m, m)
+    await cog.on_member_join(m)
+    assert len(cog.channel.sent) == 1
+
+
+async def test_dismiss_releases_the_hold(cog):
+    m = _member(user_id=46, name='Aydolf hitler')
+    await cog.on_member_join(m)
+    outcome = await cog.resolve(m.guild, 46, 'dismiss', moderator='mod')
+    assert cog.greeter.released == [46]
+    assert 'dismiss' in outcome
+
+
+async def test_ban_bans_and_says_so(cog):
+    m = _member(user_id=47, name='Aydolf hitler')
+    m.guild.fetch_member = _fetcher(m)
+    m.guild.get_member = lambda uid: m if uid == 47 else None
+    await cog.on_member_join(m)
+    outcome = await cog.resolve(m.guild, 47, 'ban', moderator='mod')
+    assert m.banned and 'ban' in outcome
+
+
+async def test_kick_after_they_already_left_is_reported(cog):
+    m = _member(user_id=48, name='Aydolf hitler')
+    m.guild.get_member = lambda uid: None
+    m.guild.fetch_member = _fetcher(None)
+    await cog.on_member_join(m)
+    outcome = await cog.resolve(m.guild, 48, 'kick', moderator='mod')
+    assert 'already' in outcome
+
+
+def _fetcher(member):
+    async def fetch_member(uid):
+        if member is None:
+            import discord
+            raise discord.NotFound(
+                types.SimpleNamespace(status=404, reason='nf'), 'Unknown')
+        return member
+    return fetch_member
+
+
+# -- AutoMod sync (bios are only reachable through Discord's own rule) ------
+
+def test_automod_keywords_cover_the_denylist_and_name_terms():
+    words = ps.automod_keywords()
+    assert 'hitler' in words and 'kike' in words
+    assert len(words) <= 1000 and all(len(w) <= 60 for w in words)
+    assert len(set(words)) == len(words)

--- a/tests/unit/test_welcome_and_rules.py
+++ b/tests/unit/test_welcome_and_rules.py
@@ -413,6 +413,40 @@ async def test_leaver_who_was_never_greeted_is_a_no_op(greeter):
     assert posted.deleted is False and posted.edits == []
 
 
+# -- hold: the profile screener can park a member (a flagged display name)
+#    so no stage greets them until a moderator dismisses the flag ----------
+
+async def test_held_member_is_not_greeted_until_released(greeter):
+    queue(greeter.join, member(51), member(52))
+    greeter.hold(52)
+    await greeter.join._flush()
+    text, _ = _in(greeter.sent, NEWBIES)[0]
+    assert '<@51>' in text and '<@52>' not in text
+
+    greeter.release(52)
+    await greeter.join._flush()
+    text, _ = _in(greeter.sent, NEWBIES)[1]
+    assert '<@52>' in text
+
+
+async def test_hold_applies_to_both_stages(greeter):
+    greeter.hold(53)
+    queue(greeter.join, member(53))
+    queue(greeter.verify, member(53))
+    await greeter.join._flush()
+    await greeter.verify._flush()
+    assert greeter.sent == []
+
+
+async def test_held_member_who_leaves_is_forgotten(greeter):
+    # Banned while on hold: nothing to greet, nothing left waiting.
+    greeter.hold(54)
+    queue(greeter.join, member(54))
+    await greeter.on_member_remove(member(54))
+    assert greeter.join._pending == []
+    assert 54 not in greeter.join.held
+
+
 async def test_retraction_api_failure_is_harmless(monkeypatch, tmp_path):
     import discord
     boom = discord.HTTPException(

--- a/tests/unit/test_welcome_and_rules.py
+++ b/tests/unit/test_welcome_and_rules.py
@@ -26,13 +26,44 @@ ROLES_CH = 1258855607281127424
 ACCESS_ROLE = 1018571935640199219
 
 
+class _Message:
+    """What a fake channel hands back from send(): remembers edits and
+    deletes so retraction tests can see what happened to the greeting."""
+    _next_id = 1000
+
+    def __init__(self, text, kw, fail=None):
+        _Message._next_id += 1
+        self.id = _Message._next_id
+        self.content = text
+        self.kwargs = kw
+        self.edits = []
+        self.deleted = False
+        self._fail = fail
+
+    async def edit(self, **kw):
+        if self._fail:
+            raise self._fail
+        self.content = kw.get('content', self.content)
+        self.edits.append(kw)
+
+    async def delete(self):
+        if self._fail:
+            raise self._fail
+        self.deleted = True
+
+
 class _Channel:
-    def __init__(self, cid, sink):
+    def __init__(self, cid, sink, fail=None):
         self.id = cid
         self._sink = sink
+        self.messages = []
+        self._fail = fail
 
     async def send(self, text, **kw):
         self._sink.append((self.id, text, kw))
+        msg = _Message(text, kw, fail=self._fail)
+        self.messages.append(msg)
+        return msg
 
 
 @pytest.fixture
@@ -314,6 +345,94 @@ async def test_all_departed_means_silence(greeter):
     # and the ghost stays marked so a rejoin isn't double-greeted... they
     # were claimed at join time; the flush must not resurrect the pending.
     assert greeter.join._pending == []
+
+
+# -- retraction: a greeted member who then leaves (or is banned) is edited
+#    out of the greeting so no client ever renders @unknown-user, and a
+#    banned troll's name does not linger in a warm welcome -----------------
+
+def _newbies_channel(greeter):
+    return greeter.bot.get_channel(NEWBIES)
+
+
+async def test_leaver_is_edited_out_of_a_recent_greeting(greeter):
+    queue(greeter.join, member(31), member(32))
+    await greeter.join._flush()
+    posted = _newbies_channel(greeter).messages[0]
+    assert '<@32>' in posted.content
+
+    await greeter.on_member_remove(member(32))
+
+    assert posted.deleted is False
+    assert '<@31>' in posted.content and '<@32>' not in posted.content
+    users = posted.edits[-1]['allowed_mentions'].users
+    assert [u.id for u in users] == [31]
+
+
+async def test_sole_leaver_deletes_the_greeting(greeter):
+    queue(greeter.join, member(33))
+    await greeter.join._flush()
+    posted = _newbies_channel(greeter).messages[0]
+
+    await greeter.on_member_remove(member(33))
+
+    assert posted.deleted is True
+
+
+async def test_leaver_is_retracted_from_both_stages(greeter):
+    queue(greeter.join, member(34))
+    await greeter.join._flush()
+    queue(greeter.verify, member(34), member(35))
+    await greeter.verify._flush()
+
+    await greeter.on_member_remove(member(34))
+
+    assert _newbies_channel(greeter).messages[0].deleted is True
+    costco = greeter.bot.get_channel(GENERAL).messages[0]
+    assert '<@34>' not in costco.content and '<@35>' in costco.content
+
+
+async def test_old_greetings_are_left_alone(greeter):
+    import time as _time
+    queue(greeter.join, member(36))
+    await greeter.join._flush()
+    posted = _newbies_channel(greeter).messages[0]
+
+    # Someone who leaves days after being welcomed is history, not a ghost.
+    later = _time.time() + greeter.join.retract_window + 1
+    await greeter.join.retract(36, now=later)
+
+    assert posted.deleted is False and posted.edits == []
+
+
+async def test_leaver_who_was_never_greeted_is_a_no_op(greeter):
+    queue(greeter.join, member(37))
+    await greeter.join._flush()
+    await greeter.on_member_remove(member(99))
+    posted = _newbies_channel(greeter).messages[0]
+    assert posted.deleted is False and posted.edits == []
+
+
+async def test_retraction_api_failure_is_harmless(monkeypatch, tmp_path):
+    import discord
+    boom = discord.HTTPException(
+        types.SimpleNamespace(status=500, reason='oops'), 'boom')
+    monkeypatch.setenv('DATA_DIR', str(tmp_path))
+    monkeypatch.setenv('WELCOME_ENABLED', 'true')
+    monkeypatch.setenv('WELCOME_ROLE_ID', str(ACCESS_ROLE))
+    monkeypatch.setenv('WELCOME_VERIFY_CHANNEL_ID', str(GENERAL))
+    monkeypatch.setenv('WELCOME_JOIN_CHANNEL_ID', str(NEWBIES))
+    monkeypatch.setenv('WELCOME_JOIN_IMAGE', '')
+    monkeypatch.setenv('WELCOME_VERIFY_IMAGE', '')
+    monkeypatch.setenv('WELCOME_JOIN_REMIND_AFTER_SECONDS', '0')
+    sent = []
+    channels = {NEWBIES: _Channel(NEWBIES, sent, fail=boom)}
+    cog = WelcomeGreeter(bot=types.SimpleNamespace(
+        get_channel=lambda cid: channels.get(cid)))
+    queue(cog.join, member(38))
+    await cog.join._flush()
+
+    await cog.on_member_remove(member(38))      # must not raise
 
 
 async def test_daily_costco_fires_at_nine_eastern(monkeypatch, tmp_path):


### PR DESCRIPTION
Two things the last screenshots surfaced.

## 1. @unknown-user
Proven client-side: every recent greeting had a fully resolved mentions array; the two ghosts were members who left or were banned after the greeting posted. Discord renders any departed user's mention as @unknown-user, however the message was sent. So the fix is after the fact: `on_member_remove` edits a leaver back out of any greeting from the last `WELCOME_RETRACT_WINDOW_SECONDS` (24h default), or deletes it when they were the only one greeted. If it ever returns, the greeting age, not the send path, is what to triage.

## 2. Profile screen (new cog, off by default)
Names get the same look messages do, at join and on every change:
- term screen: shared slur deny-list + name-only terms (`hitler`, `nazi`, `swastika`, `pedo`...) + staff/owner impersonation. `Nazim`, `Adolfo`, `kkkaty` stay clean.
- model second look via the second-stage model; only a confident `hateful` / `impersonation` flags.
- on a flag: greeter **holds** the member (no warm welcome) and a 🪪 Profile alert with restart-proof **Ban / Kick / Dismiss** lands in `MOD_ALERT_CHANNEL_ID`, marked with which stage flagged it.
- `/profile sync-automod` mirrors the term list into a Discord AutoMod member-profile rule, the only thing that can see bios.

Enable with `PROFILE_SCREEN_ENABLED=true` (reuses `MOD_ALERT_CHANNEL_ID` / `MOD_PING_ROLE_ID`). Docs in `docs/features/AI_MODERATION.md`.

Tests: 36 greeter + 20 profile, full unit suite green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)