### PR TITLE
fix: /profile sync-automod builds a member_profile trigger

### DIFF
--- a/penguin-overlord/cogs/profile_screen.py
+++ b/penguin-overlord/cogs/profile_screen.py
@@ -178,6 +178,22 @@ def automod_keywords() -> list:
 
 
 AUTOMOD_RULE_NAME = 'Penguin Overlord: profile screen'
+AUTOMOD_EVENT = discord.AutoModRuleEventType.member_update
+
+
+def automod_trigger() -> discord.AutoModTrigger:
+    """Discord has two keyword-shaped triggers: `keyword` (type 1) only pairs
+    with message_send, and `member_profile` (type 6) is the one that reads
+    names and bios on member_update. Passing keyword_filter alone defaults
+    to type 1 and the API rejects the rule, so the type is explicit."""
+    return discord.AutoModTrigger(
+        type=discord.AutoModRuleTriggerType.member_profile,
+        keyword_filter=automod_keywords())
+
+
+def automod_actions() -> list:
+    return [discord.AutoModRuleAction(
+        type=discord.AutoModRuleActionType.block_member_interactions)]
 
 
 class ProfileButton(discord.ui.DynamicItem[discord.ui.Button],
@@ -472,9 +488,8 @@ class ProfileScreen(commands.Cog):
     async def profile_sync_automod(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=True)
         guild = interaction.guild
-        trigger = discord.AutoModTrigger(keyword_filter=automod_keywords())
-        actions = [discord.AutoModRuleAction(
-            type=discord.AutoModRuleActionType.block_member_interactions)]
+        trigger = automod_trigger()
+        actions = automod_actions()
         try:
             existing = [r for r in await guild.fetch_automod_rules()
                         if r.name == AUTOMOD_RULE_NAME]
@@ -486,7 +501,7 @@ class ProfileScreen(commands.Cog):
             else:
                 await guild.create_automod_rule(
                     name=AUTOMOD_RULE_NAME,
-                    event_type=discord.AutoModRuleEventType.member_update,
+                    event_type=AUTOMOD_EVENT,
                     trigger=trigger, actions=actions, enabled=True,
                     reason='Profile screen sync')
                 what = 'created'

--- a/tests/unit/test_profile_screen.py
+++ b/tests/unit/test_profile_screen.py
@@ -254,6 +254,18 @@ def _fetcher(member):
 
 # -- AutoMod sync (bios are only reachable through Discord's own rule) ------
 
+def test_automod_rule_is_a_member_profile_rule():
+    """Discord rejects a keyword (type 1) trigger on the member_update event;
+    bios need the member_profile trigger, which shares the keyword shape."""
+    import discord
+    trigger = ps.automod_trigger()
+    assert trigger.type is discord.AutoModRuleTriggerType.member_profile
+    assert 'hitler' in trigger.keyword_filter
+    assert ps.AUTOMOD_EVENT is discord.AutoModRuleEventType.member_update
+    assert [a.type for a in ps.automod_actions()] == [
+        discord.AutoModRuleActionType.block_member_interactions]
+
+
 def test_automod_keywords_cover_the_denylist_and_name_terms():
     words = ps.automod_keywords()
     assert 'hitler' in words and 'kike' in words


### PR DESCRIPTION
First live `/profile sync-automod` failed with `Action type 4 is not permitted / Event type 2 is not permitted for rule with trigger type 1`.

`AutoModTrigger(keyword_filter=...)` defaults to trigger type 1 (`keyword`), which Discord only pairs with `message_send`. Names and bios are read by trigger type 6 (`member_profile`), same keyword shape, so the type is now explicit. A test pins the trigger / event / action triple Discord accepts together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)