### PR TITLE
feat: role picker (MEE6-style self-roles as dropdown panels)

### DIFF
--- a/README.md
+++ b/README.md
@@ -531,6 +531,7 @@ safety check
 - ✅ **systemd service support** with timers and user-based installation
 - ✅ **AI subsystem (Ollama-first)** — Arch roasts + two-stage alert-first moderation: trust tiers, community profiles, dog-whistle watchlist, attack labeling, moderator voting/relabeling, hard guardrails, per-feature models
 - ✅ **Newcomer helper** — configurable welcome pointer to rules/resources with cooldowns
+- ✅ **Role picker** — MEE6-style self-roles as persistent dropdown panels; country, US state and Canadian province panels ship, roles provisioned by `/roles post` ([guide](docs/features/ROLE_PICKER.md))
 - ✅ **Prometheus metrics** endpoint with a real gateway healthcheck
 
 ### Future Features

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,8 @@
 - **[AI Features](features/AI_MODERATION.md)** - Arch roasts and two-stage alert-first moderation: trust tiers, community profiles, dog-whistle watchlist, moderator voting and relabeling
 - **[Newcomer Helper](features/NEWCOMER_HELPER.md)** - points new members at your resources channel
 - **Welcome greeter & rules sync** - two-stage greeting: a Micro Center welcome in #welcome-newbies on join (with the verify steps), then a Costco/Idiocracy intro in #general once they verify; each batched, deduped, and greeted once. Plus daily #rules sync into the moderation prompt (see `.env.example`)
-- **[Role Management Notes](features/ROLE_MANAGEMENT_NOTES.md)** - future work: what taking over from MEE6 would involve
+- **[Role Picker](features/ROLE_PICKER.md)** - MEE6-style self-roles as persistent dropdown panels (country, US state, Canadian province), roles provisioned from JSON
+- **[Role Management Notes](features/ROLE_MANAGEMENT_NOTES.md)** - future work: the rest of taking over from MEE6 (autorole, levelling)
 - **[News System](features/NEWS_SYSTEM.md)** - 92 sources across 8 categories
 - **[News Categories](features/NEWS_CATEGORIES_OVERVIEW.md)** - Detailed category breakdown
 

--- a/docs/features/ROLE_PICKER.md
+++ b/docs/features/ROLE_PICKER.md
@@ -1,0 +1,77 @@
+# Role picker (self-roles)
+
+MEE6-style self-assign roles, built on Discord components instead of
+reactions. Members pick from a dropdown; the bot swaps their role. This is
+the first piece of the MEE6 replacement track and the thing the events
+system tags when something is happening near you.
+
+## What it does
+
+- Posts a **panel**: an embed plus one select menu per group of up to 25
+  options. Menus are persistent (fixed `custom_id`s, no stored state), so
+  a restart never orphans one.
+- **Exclusive panels** hold one role per member: picking Michigan removes
+  Ohio. Clearing the menu removes the panel's role entirely.
+- **Provisions roles** from the panel definition: `/roles post` creates
+  whatever is missing (not hoisted, not mentionable by members, so only
+  the bot can ping them) and posts the panel.
+- Refuses, and says why, when the bot lacks Manage Roles or the guild
+  would pass Discord's 250-role cap. Warns at 200.
+
+Shipped panels in `penguin-overlord/assets/role_panels/`:
+
+| key | roles | menus |
+| --- | --- | --- |
+| `country` | US and Canada first, 22 common countries, International | 1 |
+| `us_states` | 50 states + DC | 3 (alphabetical ranges) |
+| `ca_provinces` | 13 provinces and territories | 1 |
+
+Roles are named plainly (`Michigan`, `Ontario`, `Canada`) so other
+features resolve a region to a role by name.
+
+## Setup
+
+1. Give the bot **Manage Roles** and drag its role **above** where the
+   picker roles will sit (new roles are created at the bottom, so above
+   the member roles is enough).
+2. `ROLE_PICKER_ENABLED=true` in `.env`, recreate the container.
+3. In the roles channel: `/roles post country`, `/roles post us_states`,
+   `/roles post ca_provinces`. Each creates its missing roles and posts.
+4. `/roles list` shows every panel and how many of its roles exist.
+
+`/roles` defaults to members with Manage Roles; adjust in Server Settings
+> Integrations if moderators without it should post panels.
+
+## Adding or changing a panel
+
+Drop a JSON file in `assets/role_panels/`:
+
+```json
+{
+  "key": "pronouns",
+  "title": "Pronouns",
+  "description": "Pick what fits. Change any time.",
+  "exclusive": false,
+  "groups": [
+    {"placeholder": "Pronouns", "options": [
+      {"label": "he/him", "role": "he/him"},
+      {"label": "she/her", "role": "she/her"},
+      {"label": "they/them", "role": "they/them"}
+    ]}
+  ]
+}
+```
+
+Limits: 25 options per group, 5 groups per panel, role names 100 chars.
+`exclusive: false` lets a member hold several (a menu still sets one at a
+time; picking another adds it). Reposting a panel is safe: it only creates
+roles that are missing and posts a fresh copy; delete the old message by
+hand.
+
+## Notes
+
+- Menus answer ephemerally ("You are now **Michigan**. Swapped out
+  Ohio."), so the roles channel stays clean.
+- The bot never removes a role it did not define in the panel.
+- If a role in a panel was deleted by hand, members get "not set up yet,
+  ask a moderator to run /roles post" and the log records which role.

--- a/penguin-overlord/assets/role_panels/ca_provinces.json
+++ b/penguin-overlord/assets/role_panels/ca_provinces.json
@@ -1,0 +1,65 @@
+{
+  "key": "ca_provinces",
+  "title": "Canadian members: which province or territory?",
+  "description": "Pick your province or territory and you get a role for it, so event pings for your area reach you as a role and not as a personal mention.\n\nOne per person. Pick again to change, clear the menu to drop it.",
+  "exclusive": true,
+  "groups": [
+    {
+      "placeholder": "Pick your province or territory",
+      "options": [
+        {
+          "label": "Alberta",
+          "role": "Alberta"
+        },
+        {
+          "label": "British Columbia",
+          "role": "British Columbia"
+        },
+        {
+          "label": "Manitoba",
+          "role": "Manitoba"
+        },
+        {
+          "label": "New Brunswick",
+          "role": "New Brunswick"
+        },
+        {
+          "label": "Newfoundland and Labrador",
+          "role": "Newfoundland and Labrador"
+        },
+        {
+          "label": "Northwest Territories",
+          "role": "Northwest Territories"
+        },
+        {
+          "label": "Nova Scotia",
+          "role": "Nova Scotia"
+        },
+        {
+          "label": "Nunavut",
+          "role": "Nunavut"
+        },
+        {
+          "label": "Ontario",
+          "role": "Ontario"
+        },
+        {
+          "label": "Prince Edward Island",
+          "role": "Prince Edward Island"
+        },
+        {
+          "label": "Quebec",
+          "role": "Quebec"
+        },
+        {
+          "label": "Saskatchewan",
+          "role": "Saskatchewan"
+        },
+        {
+          "label": "Yukon",
+          "role": "Yukon"
+        }
+      ]
+    }
+  ]
+}

--- a/penguin-overlord/assets/role_panels/country.json
+++ b/penguin-overlord/assets/role_panels/country.json
@@ -1,0 +1,38 @@
+{
+  "key": "country",
+  "title": "Where in the world are you?",
+  "description": "Pick your country and the bot gives you a role for it. This community is primarily US and Canada focused, and international members are very welcome; if your country is not listed, take International and we will add it when there are enough of you to matter.\n\nOne country per person. Pick again to change, clear the menu to drop it.",
+  "exclusive": true,
+  "groups": [
+    {
+      "placeholder": "Pick your country",
+      "options": [
+        {"label": "United States", "emoji": "🇺🇸", "role": "United States"},
+        {"label": "Canada", "emoji": "🇨🇦", "role": "Canada"},
+        {"label": "Mexico", "emoji": "🇲🇽", "role": "Mexico"},
+        {"label": "United Kingdom", "emoji": "🇬🇧", "role": "United Kingdom"},
+        {"label": "Ireland", "emoji": "🇮🇪", "role": "Ireland"},
+        {"label": "Germany", "emoji": "🇩🇪", "role": "Germany"},
+        {"label": "France", "emoji": "🇫🇷", "role": "France"},
+        {"label": "Netherlands", "emoji": "🇳🇱", "role": "Netherlands"},
+        {"label": "Spain", "emoji": "🇪🇸", "role": "Spain"},
+        {"label": "Italy", "emoji": "🇮🇹", "role": "Italy"},
+        {"label": "Poland", "emoji": "🇵🇱", "role": "Poland"},
+        {"label": "Sweden", "emoji": "🇸🇪", "role": "Sweden"},
+        {"label": "Norway", "emoji": "🇳🇴", "role": "Norway"},
+        {"label": "Denmark", "emoji": "🇩🇰", "role": "Denmark"},
+        {"label": "Finland", "emoji": "🇫🇮", "role": "Finland"},
+        {"label": "Australia", "emoji": "🇦🇺", "role": "Australia"},
+        {"label": "New Zealand", "emoji": "🇳🇿", "role": "New Zealand"},
+        {"label": "India", "emoji": "🇮🇳", "role": "India"},
+        {"label": "Japan", "emoji": "🇯🇵", "role": "Japan"},
+        {"label": "Brazil", "emoji": "🇧🇷", "role": "Brazil"},
+        {"label": "Argentina", "emoji": "🇦🇷", "role": "Argentina"},
+        {"label": "Israel", "emoji": "🇮🇱", "role": "Israel"},
+        {"label": "South Africa", "emoji": "🇿🇦", "role": "South Africa"},
+        {"label": "Nigeria", "emoji": "🇳🇬", "role": "Nigeria"},
+        {"label": "International (other)", "emoji": "🌍", "role": "International"}
+      ]
+    }
+  ]
+}

--- a/penguin-overlord/assets/role_panels/us_states.json
+++ b/penguin-overlord/assets/role_panels/us_states.json
@@ -1,0 +1,227 @@
+{
+  "key": "us_states",
+  "title": "US members: which state?",
+  "description": "Pick your state (DC counts) and you get a role for it. This is how the events system will know to tag you when something is happening near you, and it is only ever tagged as a role, never as individual people.\n\nOne state per person. Pick again to change, clear the menu to drop it.",
+  "exclusive": true,
+  "groups": [
+    {
+      "placeholder": "Alabama to Kansas",
+      "options": [
+        {
+          "label": "Alabama",
+          "role": "Alabama"
+        },
+        {
+          "label": "Alaska",
+          "role": "Alaska"
+        },
+        {
+          "label": "Arizona",
+          "role": "Arizona"
+        },
+        {
+          "label": "Arkansas",
+          "role": "Arkansas"
+        },
+        {
+          "label": "California",
+          "role": "California"
+        },
+        {
+          "label": "Colorado",
+          "role": "Colorado"
+        },
+        {
+          "label": "Connecticut",
+          "role": "Connecticut"
+        },
+        {
+          "label": "Delaware",
+          "role": "Delaware"
+        },
+        {
+          "label": "District of Columbia",
+          "role": "District of Columbia"
+        },
+        {
+          "label": "Florida",
+          "role": "Florida"
+        },
+        {
+          "label": "Georgia",
+          "role": "Georgia"
+        },
+        {
+          "label": "Hawaii",
+          "role": "Hawaii"
+        },
+        {
+          "label": "Idaho",
+          "role": "Idaho"
+        },
+        {
+          "label": "Illinois",
+          "role": "Illinois"
+        },
+        {
+          "label": "Indiana",
+          "role": "Indiana"
+        },
+        {
+          "label": "Iowa",
+          "role": "Iowa"
+        },
+        {
+          "label": "Kansas",
+          "role": "Kansas"
+        }
+      ]
+    },
+    {
+      "placeholder": "Kentucky to North Carolina",
+      "options": [
+        {
+          "label": "Kentucky",
+          "role": "Kentucky"
+        },
+        {
+          "label": "Louisiana",
+          "role": "Louisiana"
+        },
+        {
+          "label": "Maine",
+          "role": "Maine"
+        },
+        {
+          "label": "Maryland",
+          "role": "Maryland"
+        },
+        {
+          "label": "Massachusetts",
+          "role": "Massachusetts"
+        },
+        {
+          "label": "Michigan",
+          "role": "Michigan"
+        },
+        {
+          "label": "Minnesota",
+          "role": "Minnesota"
+        },
+        {
+          "label": "Mississippi",
+          "role": "Mississippi"
+        },
+        {
+          "label": "Missouri",
+          "role": "Missouri"
+        },
+        {
+          "label": "Montana",
+          "role": "Montana"
+        },
+        {
+          "label": "Nebraska",
+          "role": "Nebraska"
+        },
+        {
+          "label": "Nevada",
+          "role": "Nevada"
+        },
+        {
+          "label": "New Hampshire",
+          "role": "New Hampshire"
+        },
+        {
+          "label": "New Jersey",
+          "role": "New Jersey"
+        },
+        {
+          "label": "New Mexico",
+          "role": "New Mexico"
+        },
+        {
+          "label": "New York",
+          "role": "New York"
+        },
+        {
+          "label": "North Carolina",
+          "role": "North Carolina"
+        }
+      ]
+    },
+    {
+      "placeholder": "North Dakota to Wyoming",
+      "options": [
+        {
+          "label": "North Dakota",
+          "role": "North Dakota"
+        },
+        {
+          "label": "Ohio",
+          "role": "Ohio"
+        },
+        {
+          "label": "Oklahoma",
+          "role": "Oklahoma"
+        },
+        {
+          "label": "Oregon",
+          "role": "Oregon"
+        },
+        {
+          "label": "Pennsylvania",
+          "role": "Pennsylvania"
+        },
+        {
+          "label": "Rhode Island",
+          "role": "Rhode Island"
+        },
+        {
+          "label": "South Carolina",
+          "role": "South Carolina"
+        },
+        {
+          "label": "South Dakota",
+          "role": "South Dakota"
+        },
+        {
+          "label": "Tennessee",
+          "role": "Tennessee"
+        },
+        {
+          "label": "Texas",
+          "role": "Texas"
+        },
+        {
+          "label": "Utah",
+          "role": "Utah"
+        },
+        {
+          "label": "Vermont",
+          "role": "Vermont"
+        },
+        {
+          "label": "Virginia",
+          "role": "Virginia"
+        },
+        {
+          "label": "Washington",
+          "role": "Washington"
+        },
+        {
+          "label": "West Virginia",
+          "role": "West Virginia"
+        },
+        {
+          "label": "Wisconsin",
+          "role": "Wisconsin"
+        },
+        {
+          "label": "Wyoming",
+          "role": "Wyoming"
+        }
+      ]
+    }
+  ]
+}

--- a/penguin-overlord/cogs/role_picker.py
+++ b/penguin-overlord/cogs/role_picker.py
@@ -1,0 +1,332 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Role Picker — MEE6-style self-roles, done with select menus.
+
+MEE6's reaction-role model predates Discord components: 20 reactions per
+message, one emoji per role, and mapping fifty states onto emoji is a
+chore nobody finishes. This cog posts persistent PANELS instead: an embed
+plus one select menu per group of up to 25 options. The selects carry their
+identity in a fixed custom_id, so they survive restarts with no state to
+store (the same DynamicItem pattern the moderation review buttons use).
+
+A panel is a JSON file in assets/role_panels/ (see country.json):
+
+    key          short id, used in custom_ids and slash-command choices
+    title        embed title
+    description  embed body, in the operator's voice
+    exclusive    true: picking one role in the panel removes the others
+    groups[]     placeholder + options[] of {label, role, emoji?}
+
+The shipped panels are country (US and Canada first, then common
+countries, then International), us_states (50 + DC across three menus),
+and ca_provinces. Roles are named plainly ("Michigan", "Ontario") so the
+events system can resolve a region to a role by name.
+
+Provisioning: `/roles post <panel> [#channel]` creates any missing roles
+(not hoisted, not mentionable by members: only the bot pings them) and
+posts the panel. It refuses, and says why, when the bot lacks Manage Roles
+or the guild would pass Discord's 250-role cap.
+
+Configuration:
+    ROLE_PICKER_ENABLED=false   master switch (commands and menus both)
+"""
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+logger = logging.getLogger(__name__)
+
+_PANELS_DIR = Path(__file__).resolve().parent.parent / 'assets' / 'role_panels'
+ROLE_CAP = 250        # Discord's hard limit per guild
+ROLE_WARN = 200       # warn early; other bots and humans make roles too
+
+
+@dataclass
+class Option:
+    label: str
+    role: str
+    emoji: str | None = None
+
+
+@dataclass
+class Group:
+    placeholder: str
+    options: list = field(default_factory=list)
+
+
+@dataclass
+class Panel:
+    key: str
+    title: str
+    description: str
+    exclusive: bool
+    groups: list = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: dict) -> 'Panel':
+        groups = [Group(g['placeholder'],
+                        [Option(o['label'], o['role'], o.get('emoji'))
+                         for o in g['options']])
+                  for g in data['groups']]
+        return cls(data['key'], data['title'], data['description'],
+                   bool(data.get('exclusive', True)), groups)
+
+    def role_names(self) -> list:
+        return [o.role for g in self.groups for o in g.options]
+
+
+def load_panels(directory: Path = _PANELS_DIR) -> dict:
+    panels = {}
+    for path in sorted(directory.glob('*.json')):
+        try:
+            panel = Panel.from_dict(json.loads(path.read_text(encoding='utf-8')))
+        except (OSError, ValueError, KeyError) as e:
+            logger.error('Role panel %s is unreadable: %s', path.name, e)
+            continue
+        panels[panel.key] = panel
+    return panels
+
+
+def missing_roles(panel: Panel, existing: set) -> list:
+    return [name for name in panel.role_names() if name not in existing]
+
+
+def plan_change(panel: Panel, member_roles: set, chosen: list) -> tuple:
+    """Pure: which panel roles to add and remove for a member's choice.
+    Unknown values are dropped (the API could never send one, but a stale
+    panel definition could), and an empty choice clears the panel."""
+    valid = set(panel.role_names())
+    wanted = [v for v in chosen if v in valid]
+    if panel.exclusive:
+        wanted = wanted[:1]
+    add = [name for name in wanted if name not in member_roles]
+    if panel.exclusive or not wanted:
+        remove = [name for name in panel.role_names()
+                  if name in member_roles and name not in wanted]
+    else:
+        remove = []
+    return add, remove
+
+
+def provision_problem(me, existing_role_count: int, needed: int) -> str | None:
+    if not me.guild_permissions.manage_roles:
+        return 'I need the Manage Roles permission to create and assign these roles.'
+    if existing_role_count + needed > ROLE_CAP:
+        return (f'This would put the server at {existing_role_count + needed} roles; '
+                f'Discord caps a server at {ROLE_CAP}.')
+    return None
+
+
+class PanelSelect(discord.ui.DynamicItem[discord.ui.Select],
+                  template=r'rolepick:(?P<panel>[a-z0-9_]+):(?P<group>[0-9]+)'):
+    """One dropdown of a panel. Everything it needs is in the custom_id and
+    the panel file, so a restart or a redeploy never orphans a menu."""
+
+    def __init__(self, panel: Panel, index: int):
+        group = panel.groups[index]
+        options = [discord.SelectOption(label=o.label, value=o.role, emoji=o.emoji)
+                   for o in group.options]
+        super().__init__(discord.ui.Select(
+            placeholder=group.placeholder, min_values=0, max_values=1,
+            options=options, custom_id=f'rolepick:{panel.key}:{index}'))
+        self.panel = panel
+        self.index = index
+
+    # DynamicItem wraps the real Select in .item; expose what tests and
+    # callers read.
+    @property
+    def options(self):
+        return self.item.options
+
+    @property
+    def min_values(self):
+        return self.item.min_values
+
+    @property
+    def max_values(self):
+        return self.item.max_values
+
+    @classmethod
+    async def from_custom_id(cls, interaction, item, match):
+        panels = load_panels()
+        panel = panels.get(match['panel'])
+        index = int(match['group'])
+        if panel is None or index >= len(panel.groups):
+            raise ValueError(f'unknown role panel {match["panel"]}:{index}')
+        return cls(panel, index)
+
+    async def callback(self, interaction: discord.Interaction):
+        cog = interaction.client.get_cog('RolePicker')
+        if cog is None or not cog.enabled:
+            await interaction.response.send_message(
+                'Role picking is switched off right now.', ephemeral=True)
+            return
+        values = list(interaction.data.get('values') or [])
+        text = await cog.apply(self.panel, interaction.guild, interaction.user, values)
+        await interaction.response.send_message(text, ephemeral=True)
+
+
+def build_view(panel: Panel) -> discord.ui.View:
+    view = discord.ui.View(timeout=None)
+    for index in range(len(panel.groups)):
+        view.add_item(PanelSelect(panel, index))
+    return view
+
+
+def build_embed(panel: Panel) -> discord.Embed:
+    return discord.Embed(title=panel.title, description=panel.description,
+                         color=0x5865F2)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in ('1', 'true', 'yes', 'on')
+
+
+class RolePicker(commands.Cog):
+    """Self-service roles from JSON-defined panels."""
+
+    def __init__(self, bot):
+        self.bot = bot
+        self.enabled = _env_bool('ROLE_PICKER_ENABLED', False)
+
+    async def cog_load(self):
+        self.bot.add_dynamic_items(PanelSelect)
+        panels = load_panels()
+        logger.info('Role picker %s: %d panels (%s)',
+                    'active' if self.enabled else 'disabled', len(panels),
+                    ', '.join(sorted(panels)) or 'none')
+
+    # -------------------------------------------------------------- apply
+
+    async def apply(self, panel: Panel, guild, member, chosen: list) -> str:
+        """Carry out a member's menu choice; returns the ephemeral reply."""
+        by_name = {r.name: r for r in guild.roles}
+        have = {r.name for r in member.roles}
+        add, remove = plan_change(panel, have, chosen)
+
+        missing = [n for n in add if n not in by_name]
+        if missing:
+            logger.error('Role panel %s: role(s) %s not provisioned', panel.key, missing)
+            return (f'The {missing[0]} role is not set up yet. Poke a moderator '
+                    f'and ask them to run /roles post {panel.key}.')
+
+        reason = f'Role picker: {panel.key}'
+        try:
+            if remove:
+                await member.remove_roles(
+                    *[by_name[n] for n in remove if n in by_name], reason=reason)
+            if add:
+                await member.add_roles(*[by_name[n] for n in add], reason=reason)
+        except discord.Forbidden:
+            logger.error('Role panel %s: Forbidden changing roles for %s',
+                         panel.key, member.display_name)
+            return ('I do not have permission to change that role. My role '
+                    'probably sits below it; tell a moderator.')
+        except discord.HTTPException as e:
+            logger.warning('Role panel %s: HTTP %s', panel.key, e.status)
+            return 'Discord did not take that change. Try again in a moment.'
+
+        logger.info('Role panel %s: %s +%s -%s', panel.key, member.display_name,
+                    add, remove)
+        if add:
+            return f'You are now **{add[0]}**.' + (
+                f' (Swapped out {", ".join(remove)}.)' if remove else '')
+        if remove:
+            return f'Cleared: {", ".join(remove)} removed.'
+        return 'No change; you already had that.'
+
+    # ----------------------------------------------------------- commands
+
+    roles = app_commands.Group(
+        name='roles', description='Self-role panels',
+        default_permissions=discord.Permissions(manage_roles=True))
+
+    @roles.command(name='list', description='List the role panels the bot knows')
+    async def roles_list(self, interaction: discord.Interaction):
+        panels = load_panels()
+        if not panels:
+            await interaction.response.send_message('No panels found.', ephemeral=True)
+            return
+        existing = {r.name for r in interaction.guild.roles}
+        lines = []
+        for key, panel in sorted(panels.items()):
+            missing = missing_roles(panel, existing)
+            lines.append(f'`{key}`: {panel.title}; {len(panel.role_names())} roles, '
+                         f'{len(missing)} not yet created')
+        await interaction.response.send_message('\n'.join(lines), ephemeral=True)
+
+    @roles.command(name='post', description='Create any missing roles for a panel and post it')
+    @app_commands.describe(panel='Panel key (see /roles list)',
+                           channel='Where to post; defaults to here')
+    async def roles_post(self, interaction: discord.Interaction, panel: str,
+                         channel: discord.TextChannel | None = None):
+        if not self.enabled:
+            await interaction.response.send_message(
+                'ROLE_PICKER_ENABLED is off; menus would not respond.', ephemeral=True)
+            return
+        panels = load_panels()
+        definition = panels.get(panel)
+        if definition is None:
+            await interaction.response.send_message(
+                f'No panel called `{panel}`. Known: {", ".join(sorted(panels))}',
+                ephemeral=True)
+            return
+        await interaction.response.defer(ephemeral=True)
+        guild = interaction.guild
+        existing = {r.name for r in guild.roles}
+        missing = missing_roles(definition, existing)
+        problem = provision_problem(guild.me, len(guild.roles), len(missing))
+        if problem:
+            await interaction.followup.send(problem, ephemeral=True)
+            return
+
+        created = []
+        try:
+            for name in missing:
+                await guild.create_role(name=name, hoist=False, mentionable=False,
+                                        reason=f'Role picker panel {definition.key}')
+                created.append(name)
+        except discord.HTTPException as e:
+            await interaction.followup.send(
+                f'Created {len(created)} of {len(missing)} roles, then Discord '
+                f'refused: {e.text or type(e).__name__}. Fix and rerun; it only '
+                f'creates what is missing.', ephemeral=True)
+            return
+
+        target = channel or interaction.channel
+        try:
+            await target.send(embed=build_embed(definition), view=build_view(definition))
+        except discord.Forbidden:
+            await interaction.followup.send(
+                f'Roles are ready but I cannot post in {target.mention}.', ephemeral=True)
+            return
+
+        note = ''
+        if len(guild.roles) + len(created) >= ROLE_WARN:
+            note = (f'\nHeads up: the server is at about {len(guild.roles) + len(created)} '
+                    f'roles; Discord stops at {ROLE_CAP}.')
+        await interaction.followup.send(
+            f'Posted `{definition.key}` in {target.mention}; created {len(created)} '
+            f'role(s).{note}', ephemeral=True)
+
+    @roles_post.autocomplete('panel')
+    async def _panel_autocomplete(self, interaction: discord.Interaction, current: str):
+        return [app_commands.Choice(name=k, value=k)
+                for k in sorted(load_panels()) if current.lower() in k][:25]
+
+
+async def setup(bot):
+    await bot.add_cog(RolePicker(bot))
+    logger.info('RolePicker cog loaded')

--- a/tests/unit/test_role_picker.py
+++ b/tests/unit/test_role_picker.py
@@ -1,0 +1,193 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Role picker: MEE6-style self-roles as persistent select menus, one role
+per exclusive panel, roles provisioned from the JSON panel definitions."""
+
+import types
+
+import discord
+import pytest
+
+from cogs import role_picker as rp
+from cogs.role_picker import RolePicker
+
+
+# -- shipped panel definitions ----------------------------------------------
+
+def test_shipped_panels_load_and_fit_discord_limits():
+    panels = rp.load_panels()
+    assert set(panels) >= {'country', 'us_states', 'ca_provinces'}
+    for key, panel in panels.items():
+        assert panel.key == key
+        assert 1 <= len(panel.groups) <= 5, key          # one action row each
+        for group in panel.groups:
+            assert 1 <= len(group.options) <= 25, key    # select option cap
+        roles = panel.role_names()
+        assert len(roles) == len(set(roles)), key        # no duplicates
+
+
+def test_us_states_panel_has_fifty_states_plus_dc():
+    panel = rp.load_panels()['us_states']
+    assert len(panel.role_names()) == 51
+    assert 'Michigan' in panel.role_names()
+    assert 'District of Columbia' in panel.role_names()
+
+
+def test_country_panel_leads_with_us_and_canada():
+    panel = rp.load_panels()['country']
+    first_two = [o.role for o in panel.groups[0].options[:2]]
+    assert first_two == ['United States', 'Canada']
+    assert 'International' in panel.role_names()
+
+
+def test_provinces_panel_has_thirteen():
+    assert len(rp.load_panels()['ca_provinces'].role_names()) == 13
+
+
+# -- the pure decisions ------------------------------------------------------
+
+def _panel():
+    return rp.Panel.from_dict({
+        'key': 'demo', 'title': 't', 'description': 'd', 'exclusive': True,
+        'groups': [{'placeholder': 'p', 'options': [
+            {'label': 'Ohio', 'role': 'Ohio'},
+            {'label': 'Michigan', 'role': 'Michigan'},
+        ]}],
+    })
+
+
+def test_missing_roles_are_the_ones_the_guild_lacks():
+    assert rp.missing_roles(_panel(), {'Ohio', 'Penguins'}) == ['Michigan']
+
+
+def test_choosing_a_role_swaps_out_the_old_one():
+    add, remove = rp.plan_change(_panel(), {'Ohio', 'Penguins'}, ['Michigan'])
+    assert add == ['Michigan'] and remove == ['Ohio']
+
+
+def test_choosing_the_same_role_again_is_a_noop():
+    add, remove = rp.plan_change(_panel(), {'Michigan'}, ['Michigan'])
+    assert add == [] and remove == []
+
+
+def test_clearing_the_menu_drops_every_panel_role():
+    add, remove = rp.plan_change(_panel(), {'Michigan', 'Penguins'}, [])
+    assert add == [] and remove == ['Michigan']
+
+
+def test_unknown_value_is_ignored_not_granted():
+    add, remove = rp.plan_change(_panel(), set(), ['Administrator'])
+    assert add == [] and remove == []
+
+
+# -- view construction --------------------------------------------------------
+
+def test_view_has_one_persistent_select_per_group():
+    panel = rp.load_panels()['us_states']
+    view = rp.build_view(panel)
+    ids = [item.custom_id for item in view.children]
+    assert ids == ['rolepick:us_states:0', 'rolepick:us_states:1', 'rolepick:us_states:2']
+    assert view.timeout is None
+    select = view.children[0]
+    assert select.min_values == 0 and select.max_values == 1
+    assert len(select.options) == 17
+
+
+def test_select_option_values_are_role_names_with_emoji_when_given():
+    view = rp.build_view(rp.load_panels()['country'])
+    first = view.children[0].options[0]
+    assert first.value == 'United States' and str(first.emoji) == '🇺🇸'
+
+
+# -- the cog applying a choice -------------------------------------------------
+
+def _role(name, rid):
+    return types.SimpleNamespace(name=name, id=rid, mention=f'<@&{rid}>')
+
+
+def _member(roles):
+    m = types.SimpleNamespace(roles=list(roles), added=[], removed=[],
+                              display_name='someone')
+
+    async def add_roles(*rs, reason=None):
+        m.added.extend(r.name for r in rs)
+
+    async def remove_roles(*rs, reason=None):
+        m.removed.extend(r.name for r in rs)
+    m.add_roles = add_roles
+    m.remove_roles = remove_roles
+    return m
+
+
+def _guild(role_names):
+    roles = [_role(n, 100 + i) for i, n in enumerate(role_names)]
+    return types.SimpleNamespace(roles=roles)
+
+
+@pytest.fixture
+def cog(monkeypatch):
+    monkeypatch.setenv('ROLE_PICKER_ENABLED', 'true')
+    return RolePicker(types.SimpleNamespace())
+
+
+async def test_apply_swaps_roles_and_reports(cog):
+    panel = _panel()
+    guild = _guild(['Ohio', 'Michigan', 'Penguins'])
+    member = _member([guild.roles[0], guild.roles[2]])   # Ohio + Penguins
+    text = await cog.apply(panel, guild, member, ['Michigan'])
+    assert member.added == ['Michigan'] and member.removed == ['Ohio']
+    assert 'Michigan' in text
+
+
+async def test_apply_with_nothing_chosen_clears(cog):
+    panel = _panel()
+    guild = _guild(['Ohio', 'Michigan'])
+    member = _member([guild.roles[1]])
+    text = await cog.apply(panel, guild, member, [])
+    assert member.removed == ['Michigan'] and member.added == []
+    assert 'cleared' in text.lower() or 'removed' in text.lower()
+
+
+async def test_apply_when_role_is_missing_from_guild_says_so(cog):
+    panel = _panel()
+    guild = _guild(['Ohio'])                  # Michigan was never provisioned
+    member = _member([])
+    text = await cog.apply(panel, guild, member, ['Michigan'])
+    assert member.added == []
+    assert 'moderator' in text.lower() or 'not set up' in text.lower()
+
+
+async def test_apply_forbidden_is_a_message_not_a_crash(cog):
+    panel = _panel()
+    guild = _guild(['Ohio', 'Michigan'])
+    member = _member([])
+
+    async def add_roles(*rs, reason=None):
+        raise discord.Forbidden(types.SimpleNamespace(status=403, reason='f'), 'nope')
+    member.add_roles = add_roles
+    text = await cog.apply(panel, guild, member, ['Michigan'])
+    assert 'permission' in text.lower()
+
+
+# -- provisioning guard --------------------------------------------------------
+
+def test_provision_check_refuses_without_manage_roles():
+    me = types.SimpleNamespace(guild_permissions=discord.Permissions(manage_roles=False),
+                               top_role=types.SimpleNamespace(position=50))
+    problem = rp.provision_problem(me, existing_role_count=10, needed=5)
+    assert problem and 'Manage Roles' in problem
+
+
+def test_provision_check_refuses_past_the_role_cap():
+    me = types.SimpleNamespace(guild_permissions=discord.Permissions(manage_roles=True),
+                               top_role=types.SimpleNamespace(position=50))
+    problem = rp.provision_problem(me, existing_role_count=248, needed=5)
+    assert problem and '250' in problem
+
+
+def test_provision_check_passes_when_fine():
+    me = types.SimpleNamespace(guild_permissions=discord.Permissions(manage_roles=True),
+                               top_role=types.SimpleNamespace(position=50))
+    assert rp.provision_problem(me, existing_role_count=80, needed=51) is None


### PR DESCRIPTION
Sub-project 1 of the events work, and the first MEE6 replacement piece.

**What it does**
- Posts a panel: embed + one persistent select menu per group of up to 25 options (`DynamicItem`, fixed `custom_id`s, survives restarts with no stored state).
- Exclusive panels hold one role per member: picking Michigan removes Ohio; clearing the menu drops it. Replies are ephemeral.
- `/roles post <panel> [#channel]` creates any missing roles (not hoisted, not member-mentionable, so only the bot pings them) and posts the panel. Refuses with a reason when the bot lacks Manage Roles or the guild would pass the 250-role cap; warns at 200. `/roles list` shows panel state.

**Shipped panels** (`penguin-overlord/assets/role_panels/`): `country` (US, Canada, 22 common countries, International), `us_states` (50 + DC, three alphabetical menus), `ca_provinces` (13). Roles are named plainly (`Michigan`, `Ontario`) so events can resolve region to role by name.

**Setup after merge:** bot needs Manage Roles with its role above the picker roles; `ROLE_PICKER_ENABLED=true`; then `/roles post country|us_states|ca_provinces` in the roles channel.

Off by default. 18 tests, full suite green, ruff clean. Guide: `docs/features/ROLE_PICKER.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)