### PR TITLE
fix: greeter join reminder anchors on membership screening, not the gateway join

### DIFF
--- a/penguin-overlord/cogs/welcome_greeter.py
+++ b/penguin-overlord/cogs/welcome_greeter.py
@@ -74,7 +74,10 @@ Configuration:
     WELCOME_JOIN_REMIND_AFTER_SECONDS=300  wait this long after a join;
                                      members who verified (gained
                                      WELCOME_ROLE_ID) or left by then are
-                                     silently skipped
+                                     silently skipped. With membership
+                                     screening on, "join" means clicking
+                                     through the rules screen (when MEE6
+                                     says hello), not the gateway join.
     WELCOME_JOIN_DAILY_AT=           HH:MM in WELCOME_TIMEZONE for one
                                      reminder batch per day (optional)
     WELCOME_JOIN_IMAGE=              attached image ('' = none)
@@ -402,7 +405,9 @@ class _GreetStage:
         left = verified = 0
         for m in members:
             fresh = await self._resolve(m)
-            if fresh is None:
+            if fresh is None or getattr(fresh, 'pending', False):
+                # gone, or still on the membership screening rules page:
+                # either way they cannot read the greeting
                 left += 1
                 continue
             if self.skip_role_id is not None and any(
@@ -412,8 +417,8 @@ class _GreetStage:
                 continue
             keep.append(fresh)
         if left or verified:
-            logger.info('%s welcome: dropped %d departed and %d already-'
-                        'verified member(s) before the flush', self.name,
+            logger.info('%s welcome: dropped %d departed-or-unscreened and %d '
+                        'already-verified member(s) before the flush', self.name,
                         left, verified)
         if not keep:
             return
@@ -590,6 +595,18 @@ class WelcomeGreeter(commands.Cog):
 
     @commands.Cog.listener()
     async def on_member_join(self, member: discord.Member):
+        # With membership screening on, this fires the instant someone clicks
+        # Join, while they are still on the rules screen and can see no
+        # channel. MEE6 greets when they click through; anchor the reminder
+        # on that same moment (the pending flip, below) or a slow reader
+        # gets our reminder before the hello.
+        if getattr(member, 'pending', False):
+            logger.info('Join welcome for %s deferred: still behind the '
+                        'membership screening gate', member)
+            return
+        self._queue_join(member)
+
+    def _queue_join(self, member: discord.Member):
         if not self.join.enabled or member.bot:
             return
         if self.join.seen(member.id):
@@ -600,7 +617,12 @@ class WelcomeGreeter(commands.Cog):
 
     @commands.Cog.listener()
     async def on_member_update(self, before: discord.Member, after: discord.Member):
-        if not self.verify.enabled or after.bot:
+        if after.bot:
+            return
+        if (getattr(before, 'pending', False)
+                and not getattr(after, 'pending', False)):
+            self._queue_join(after)
+        if not self.verify.enabled:
             return
         if self.role_id in {r.id for r in before.roles}:
             return

--- a/tests/unit/test_welcome_and_rules.py
+++ b/tests/unit/test_welcome_and_rules.py
@@ -93,9 +93,9 @@ def greeter(monkeypatch, tmp_path):
     return cog
 
 
-def member(user_id=42, roles=(), bot=False):
+def member(user_id=42, roles=(), bot=False, pending=False):
     m = types.SimpleNamespace(
-        id=user_id, bot=bot, mention=f'<@{user_id}>',
+        id=user_id, bot=bot, mention=f'<@{user_id}>', pending=pending,
         roles=[types.SimpleNamespace(id=r) for r in roles],
     )
     m.__str__ = lambda self: f'user{user_id}'
@@ -652,3 +652,40 @@ def test_missing_rules_cache_changes_nothing(monkeypatch, tmp_path):
     import ai.features.moderation as mod
     monkeypatch.setattr(mod, '_RULES_CACHE', None)
     assert "OWN RULES" not in mod.moderation_system_prompt()
+
+
+# -- Discord membership screening: on_member_join fires the instant someone
+#    clicks Join, while they are still on the rules screen and can see no
+#    channel. MEE6 greets when they click through (pending True -> False).
+#    Anchor the reminder there too, or a slow reader gets our reminder
+#    BEFORE the hello (seen live: reminder 11:15:03Z, MEE6 11:15:47Z) -------
+
+async def test_join_reminder_waits_for_the_screening_gate(greeter):
+    gated = member(61, pending=True)
+    await greeter.on_member_join(gated)
+    assert greeter.join._pending == []            # not even queued yet
+
+    await greeter.on_member_update(member(61, pending=True),
+                                   member(61, pending=False))
+    assert [m.id for m, _ in greeter.join._pending] == [61]
+
+    # the flip is not a second join: no double claim
+    await greeter.on_member_update(member(61, pending=True),
+                                   member(61, pending=False))
+    assert len(greeter.join._pending) == 1
+
+
+async def test_servers_without_screening_queue_on_join(greeter):
+    await greeter.on_member_join(member(62, pending=False))
+    assert [m.id for m, _ in greeter.join._pending] == [62]
+
+
+async def test_members_still_on_the_rules_screen_are_not_pinged(greeter):
+    # Queued somehow but never clicked through by flush time: they cannot
+    # read the channel, so a mention is noise for everyone else.
+    stuck = member(63)
+    lookup = {63: member(63, pending=True)}
+    stuck.guild = types.SimpleNamespace(get_member=lambda uid: lookup.get(uid))
+    queue(greeter.join, stuck)
+    await greeter.join._flush()
+    assert greeter.sent == []


### PR DESCRIPTION
## The bug

This morning mchughster got the Micro Center reminder at 07:15:03 ET and MEE6's hello at 07:15:47 ET, 44 seconds later. The reminder is supposed to follow the hello by a few minutes.

The bot honored its own timing: gateway join 07:07:21, five-minute minimum, next :15 boundary. The 8-minute gap is on the other side. The guild has Discord **membership screening** enabled (`MEMBER_VERIFICATION_GATE_ENABLED`), so `on_member_join` fires the instant someone clicks Join while they're still on the rules screen and can't see any channel. MEE6 greets when they click through (`member.pending` flips True to False). Evidence from the channel history, all UTC:

| member | gateway join | MEE6 hello | our reminder |
|---|---|---|---|
| browniespot | 21:08:03 | 21:08:21 | 21:15:07 |
| otisburger | 20:53:10 | 20:56:14 | 21:00:07 |
| mchughster | 11:07:21 | 11:15:47 | 11:15:03 |

Two members in that history (`otisburger`, `nevastuica888`) are still `pending: true` and were mentioned in a reminder they cannot read.

## The fix

- `on_member_join`: a pending member is not queued (logged as deferred).
- `on_member_update`: the pending True to False flip queues them through the same claim, so the flip is never a second join and servers without screening behave exactly as before.
- Flush: members still pending are dropped alongside the departed ones (log line now says "departed-or-unscreened").

## Tests (TDD, RED then GREEN)

- `test_join_reminder_waits_for_the_screening_gate`
- `test_servers_without_screening_queue_on_join` (regression guard)
- `test_members_still_on_the_rules_screen_are_not_pinged`

Full unit suite green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
