### PR TITLE
feat: typed config loaded once at startup, every problem in one error

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,7 @@ Complete documentation lives in the [`docs/`](docs/) directory:
 - 📰 **[News System Guide](docs/features/NEWS_SYSTEM.md)**
 - ⚙️ **[Channel Configuration](docs/reference/CHANNEL_CONFIGURATION.md)**
 - 🪵 **[Logging & rotation](docs/reference/LOGGING.md)**
+- ✅ **[Configuration & startup validation](docs/reference/CONFIGURATION.md)**
 - 🚢 **[Production Deployment](docs/deployment/PRODUCTION.md)** · [systemd](docs/deployment/SYSTEMD.md)
 
 ## 🔐 Secret Management

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,6 +44,7 @@
 - **[News Optimization](reference/NEWS_OPTIMIZATION.md)** - Performance tuning guide
 - **[Help System](reference/HELP_SYSTEM.md)** - Using the categorized help system
 - **[Logging](reference/LOGGING.md)** - Log levels, rotation, and what to grep for
+- **[Configuration](reference/CONFIGURATION.md)** - How env vars are loaded and validated, `check-config.py`, adding a variable
 
 ### 📦 Archive
 Historical documentation, kept for reference and not to be followed:

--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -1,0 +1,146 @@
+# Configuration loading
+
+`penguin-overlord/utils/config.py` reads the whole environment once, at
+startup, and turns it into a frozen `Config` object. Every entry point
+(`bot.py` and the news, KEV, solar, xkcd and comics runners) calls
+`load_config()` before it does anything else. If any variable is missing
+or malformed the process logs one error listing all of them and exits 1.
+
+Before this module each feature ran its own `os.getenv` calls. A typo in
+one channel id showed up hours later as a silent no-post, and a missing
+token gave a different error in each of the six entry points.
+
+## What a failure looks like
+
+```
+❌ Refusing to start:
+3 configuration problems:
+  - DISCORD_BOT_TOKEN: required, not set
+  - NEWS_TECH_CHANNEL_ID: expected a Discord id (17 to 20 digits), got 'general'
+  - METRICS_PORT: expected an integer between 1 and 65535, got 'x'
+```
+
+Values are echoed only for non-secret variables, and truncated to 32
+characters. Anything that reaches the secrets manager (`DISCORD_*`,
+`GEMINI_*`, and so on) is reported by name alone.
+
+## Checking without starting the bot
+
+```
+python scripts/check-config.py
+docker compose run --rm penguin-overlord python scripts/check-config.py
+```
+
+Prints `OK:` followed by a counts-only summary (how many news channels
+are set, which posters and AI features are on), or `FAIL:` with the same
+list the bot would log. Exit code 0 or 1. It loads `.env` and the secrets
+manager exactly the way `bot.py` does, so it validates what production
+would actually run with.
+
+## Sections
+
+`Config` is a frozen dataclass of frozen dataclasses, grouped by concern:
+
+| Section | Variables | Notes |
+|---|---|---|
+| `discord` | `DISCORD_BOT_TOKEN`, `DISCORD_OWNER_ID` | The token is the only required variable. `DISCORD_TOKEN` is accepted as an alias because the runners historically read it. |
+| `logging` | `LOG_LEVEL`, `LOG_FILE`, `LOG_MAX_BYTES`, `LOG_BACKUPS` | See [Logging](LOGGING.md). |
+| `paths` | `DATA_DIR`, `BOT_DATABASE_PATH`, `XKCD_STATE_PATH`, `COMIC_STATE_PATH` | Paths are not checked for existence. |
+| `news` | `NEWS_<CATEGORY>_CHANNEL_ID` for the 11 categories, `NEWS_AUTO_POST` | `config.news.channel_id('kev')` or `config.news.kev`. See [Channel Configuration](CHANNEL_CONFIGURATION.md). |
+| `posting` | `XKCD_POST_CHANNEL_ID`, `XKCD_POLL_INTERVAL_MINUTES`, `COMIC_POST_CHANNEL_ID`, `SOLAR_POST_CHANNEL_ID` | |
+| `metrics` | `METRICS_ENABLED`, `METRICS_PORT` | |
+| `ai` | `AI_*`, `OLLAMA_*`, `GEMINI_API_KEY` | Global defaults plus a per-feature `AiFeatureConfig` for roasting, moderation, news, cve and legislation. |
+| `moderation` | `MOD_*`, `AI_MODERATION_SECOND_*` | |
+| `greeter` | `WELCOME_*` | |
+| `helper` | `HELPER_*` | |
+| `role_picker` | `ROLE_PICKER_ENABLED` | |
+| `profile_screen` | `PROFILE_SCREEN_*` | |
+| `skid_detector` | `SKID_DETECTOR_*`, `SKID_FIRE_CHANCE`, `SKID_COOLDOWN_SECONDS` | |
+| `banter` | `ARCH_BANTER_LLM` | |
+
+Optional features default off. Defaults and per-variable descriptions
+live in `.env.example`.
+
+The secrets-manager bootstrap variables (`SECRETS_MANAGER`, `DOPPLER_*`,
+`SECRETS_VAULT_*`, `AWS_SECRET_NAME`, `VAULT_SECRET_PATH`) are read by
+`utils/secrets.py` itself and are deliberately not part of `Config`; the
+config loader depends on them.
+
+## Value shapes
+
+| Shape | Accepted |
+|---|---|
+| bool | `true/false`, `yes/no`, `on/off`, `1/0`, case-insensitive |
+| int | Digits, with an optional minimum and maximum per variable |
+| snowflake | 17 to 20 digits. `<#id>`, `<@id>`, `<@&id>` and surrounding quotes are stripped first, so a pasted channel mention works |
+| snowflake list | Comma or whitespace separated ids; each bad entry is reported |
+| word list | Comma-separated, whitespace trimmed, lower-cased unless noted |
+| time | `HH:MM`, 24-hour |
+| timezone | An IANA name that `zoneinfo` can load |
+| log level | `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL` |
+
+An empty string is the same as unset. A value starting with `your_` is
+also treated as unset, so an unedited `.env.example` placeholder reports
+"required, not set" rather than being sent to Discord as a token.
+
+## Secrets
+
+Values are resolved in the same order the cogs always used: the secrets
+manager first (`utils.secrets.get_secret(platform, key)`, where the
+platform is the variable's prefix, `MOD` for `MOD_ALERT_CHANNEL_ID`),
+then the process environment, which `load_dotenv()` has already filled
+from `.env`.
+
+Secret-shaped values (`DISCORD_BOT_TOKEN`, `GEMINI_API_KEY`) are wrapped
+in `Secret`. Its `repr` and `str` are `Secret(***)`, the token field is
+excluded from the dataclass repr, and nothing in this module logs a value.
+Call `.reveal()` at the one place the raw string is needed, which is
+`bot.run()` or `client.start()`.
+
+## Import-time reads
+
+Three things must be configured before `load_config()` can run: logging
+(so the config error has somewhere to go), the metrics module constants,
+and the runners' `DATA_DIR`. They use the lenient section loaders
+`load_logging_config()`, `load_metrics_config()` and
+`load_paths_config()`, which substitute defaults for anything malformed
+and never raise. The same malformed value is then reported by
+`load_config()` a moment later, so nothing is swallowed.
+
+## In tests
+
+`load_config(env={...})` takes a plain mapping and never touches
+`os.environ`, `.env` or a secrets manager. Build the smallest environment
+the test needs:
+
+```python
+config = load_config({'DISCORD_BOT_TOKEN': 'x', 'NEWS_KEV_CHANNEL_ID': '123456789012345678'})
+assert config.news.kev == 123456789012345678
+```
+
+To assert on the error list, catch `ConfigError` and inspect `.problems`.
+
+## Adding a variable
+
+1. Add a typed field with a default to the section dataclass in
+   `utils/config.py`. If no section fits, add a new frozen dataclass and
+   a field for it on `Config`.
+2. Read it in that section's `_load_*` function with the matching
+   `_Reader` method (`r.bool`, `r.snowflake`, `r.words`, ...). Pass
+   `minimum`/`maximum` for ints that have a sane range. Use `r.secret`
+   for anything that should never be echoed.
+3. If the prefix is new and should be resolvable through the secrets
+   manager, add it to `_SECRET_PLATFORMS`.
+4. Document it in `.env.example` and, if it belongs to a feature guide,
+   there too.
+5. Add a case to `tests/unit/test_config.py`: the happy path, and the
+   error text for one malformed value.
+6. Read it from `config.<section>.<field>` in the code. Cogs that have
+   not migrated yet can still call `os.getenv`, but new code should not.
+
+## Migration status
+
+Migrated: `bot.py`, the five runners, `utils/logging_setup.py`,
+`utils/metrics.py`. Cogs and the `ai/` package still read the environment
+themselves; the bot exposes `self.config` so they can switch over one at
+a time.

--- a/penguin-overlord/bot.py
+++ b/penguin-overlord/bot.py
@@ -7,25 +7,25 @@ Penguin Overlord - A fun Discord bot with various features.
 Main bot entry point.
 """
 
-import os
+import sys
 from pathlib import Path
 import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
-# Import secrets management
-from utils.secrets import get_secret
+from utils.config import Config, ConfigError, describe_config, load_config
 from utils.logging_setup import configure_logging, describe_logging
+
+# Load environment variables (fallback if not using secrets manager).
+# Before logging is configured, so a LOG_LEVEL in .env is honoured.
+load_dotenv()
 
 logger = configure_logging('bot')
 
-# Load environment variables (fallback if not using secrets manager)
-load_dotenv()
-
 class PenguinOverlord(commands.Bot):
     """The Penguin Overlord Discord bot."""
-    
-    def __init__(self):
+
+    def __init__(self, config: Config = None):
         intents = discord.Intents.default()
         intents.message_content = True
         # Server Members Intent: without it Discord never delivers
@@ -34,26 +34,18 @@ class PenguinOverlord(commands.Bot):
         # in the Developer Portal (Application → Bot → Server Members Intent).
         intents.members = True
 
-        # Get owner ID from environment or secrets
-        owner_id = get_secret('DISCORD', 'OWNER_ID')
-        if not owner_id:
-            owner_id = os.getenv('DISCORD_OWNER_ID')
-        
-        # Parse owner_id, handling placeholder values gracefully
-        parsed_owner_id = None
-        if owner_id and owner_id.isdigit():
-            parsed_owner_id = int(owner_id)
-        elif owner_id and not owner_id.startswith('your_'):
-            # Log warning if invalid but not a placeholder
-            print(f"⚠️  Warning: DISCORD_OWNER_ID '{owner_id}' is not a valid Discord user ID")
-        
+        # Validated once in main(); None only in tests that build the bot
+        # without an environment. Cogs still read the environment themselves
+        # until they migrate to `self.bot.config`.
+        self.config = config
+
         super().__init__(
             command_prefix='!',
             intents=intents,
             description='Penguin Overlord - Your fun companion bot!',
-            owner_id=parsed_owner_id
+            owner_id=config.discord.owner_id if config else None
         )
-        
+
         # Completely disable the default help command
         self.help_command = None
     
@@ -120,31 +112,26 @@ class PenguinOverlord(commands.Bot):
 
 def main():
     """Main entry point for the bot."""
-    # Try to get token from secrets manager first, then fall back to env var
-    token = get_secret('DISCORD', 'BOT_TOKEN')
-    
-    # If not in secrets manager, try direct env var
-    if not token:
-        token = os.getenv('DISCORD_BOT_TOKEN')
-    
-    if not token:
-        logger.error("❌ DISCORD_BOT_TOKEN not found!")
-        logger.error("You can set it via:")
-        logger.error("  1. Doppler: Set DOPPLER_TOKEN env var and add DISCORD_BOT_TOKEN to your Doppler project")
-        logger.error("  2. AWS Secrets Manager: Set SECRETS_MANAGER=aws and configure AWS credentials")
-        logger.error("  3. HashiCorp Vault: Set SECRETS_MANAGER=vault and configure Vault credentials")
-        logger.error("  4. .env file: Create .env with DISCORD_BOT_TOKEN=your_token")
-        logger.error("See .env.example for reference.")
-        return
-    
-    logger.info('Penguin Overlord starting — logging %s', describe_logging())
+    # One pass over the environment (secrets manager first, then .env):
+    # every missing or malformed variable is reported together, and the
+    # process exits non-zero so a container restart loop is visible.
+    try:
+        config = load_config()
+    except ConfigError as e:
+        logger.error("❌ Refusing to start:\n%s", e)
+        logger.error("See .env.example and docs/reference/CONFIGURATION.md; "
+                     "`python scripts/check-config.py` re-runs this check.")
+        sys.exit(1)
 
-    bot = PenguinOverlord()
+    logger.info('Penguin Overlord starting — logging %s', describe_logging())
+    logger.info('Config: %s', describe_config(config))
+
+    bot = PenguinOverlord(config)
 
     try:
         # log_handler=None: discord.py otherwise installs its own root
         # handler alongside ours and every discord.* record is logged twice.
-        bot.run(token, log_handler=None)
+        bot.run(config.discord.bot_token.reveal(), log_handler=None)
     except discord.LoginFailure:
         logger.error("❌ Invalid Discord bot token!")
     except Exception as e:

--- a/penguin-overlord/comics_runner.py
+++ b/penguin-overlord/comics_runner.py
@@ -12,7 +12,7 @@ Runs independently of the main bot process for reliability.
 Usage:
     python comics_runner.py
     
-Environment Variables:
+Environment Variables (validated by utils.config at startup):
     DISCORD_BOT_TOKEN - Required (supports Doppler via get_secret)
     COMIC_POST_CHANNEL_ID - Required (channel ID for posting)
 """
@@ -36,8 +36,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # Load environment
 load_dotenv()
 
-# Import secrets utility
-from utils.secrets import get_secret
+from utils.config import Config, ConfigError, load_config, load_paths_config
 from utils.logging_setup import configure_logging
 from utils.state import load_json_state, save_json_state
 
@@ -45,7 +44,8 @@ from utils.state import load_json_state, save_json_state
 logger = configure_logging('comics_runner')
 
 
-DATA_DIR = os.getenv('DATA_DIR') or ('/app/data' if os.path.exists('/app/data') else 'data')
+# Prefer mounted data directory (Docker) or user-specified DATA_DIR, fallback to local data/
+DATA_DIR = str(load_paths_config().data_dir)
 STATE_FILE = Path(DATA_DIR) / 'comic_state.json'
 
 
@@ -141,16 +141,15 @@ async def fetch_turnoff(session: aiohttp.ClientSession) -> dict | None:
     return None
 
 
-async def post_comic_update():
+async def post_comic_update(settings: Config = None):
     """Fetch and post daily tech comic."""
-    token = get_secret('DISCORD', 'BOT_TOKEN')
-    # Prefer persisted channel in state if present (set via runtime command)
+    if settings is None:
+        settings = load_config()
+    token = settings.discord.bot_token.reveal()
+    # Prefer persisted channel in state if present (set via runtime command);
+    # the environment value arrives already validated as a Discord id.
     state = load_state()
-    channel_id = state.get('channel_id') or get_secret('COMIC', 'POST_CHANNEL_ID')
-    
-    if not token:
-        logger.error("DISCORD_BOT_TOKEN not set")
-        return False
+    channel_id = state.get('channel_id') or settings.posting.comic_channel_id
     
     if not channel_id:
         logger.error("COMIC_POST_CHANNEL_ID not set")
@@ -173,7 +172,7 @@ async def post_comic_update():
         logger.info(f"Comic already posted today ({today})")
         return True
     
-    # Sanitize channel id if provided in formats like '<#12345>' or '12345' or '"12345"'
+    # Sanitize a state-file channel id in formats like '<#12345>' or '12345' or '"12345"'
     try:
         if isinstance(channel_id, str):
             sanitized = ''.join(ch for ch in channel_id if ch.isdigit())
@@ -283,7 +282,12 @@ async def post_comic_update():
 if __name__ == '__main__':
     logger.info("Comics runner starting...")
     try:
-        asyncio.run(post_comic_update())
+        settings = load_config()
+    except ConfigError as e:
+        logger.error("Refusing to run:\n%s", e)
+        sys.exit(1)
+    try:
+        asyncio.run(post_comic_update(settings))
         logger.info("Comics runner completed")
         sys.exit(0)
     except Exception as e:

--- a/penguin-overlord/kev_runner.py
+++ b/penguin-overlord/kev_runner.py
@@ -12,8 +12,8 @@ Runs independently of the main bot process for reliability.
 Usage:
     python kev_runner.py
     
-Environment Variables:
-    DISCORD_TOKEN - Required
+Environment Variables (validated by utils.config at startup):
+    DISCORD_BOT_TOKEN - Required (DISCORD_TOKEN accepted as an alias)
     NEWS_KEV_CHANNEL_ID - Required (channel ID for posting)
 """
 
@@ -36,7 +36,7 @@ from dotenv import load_dotenv
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from utils.secrets import get_secret
+from utils.config import Config, ConfigError, load_config
 from utils.logging_setup import configure_logging
 from utils.state import load_json_state, save_json_state
 
@@ -190,29 +190,16 @@ async def fetch_kevs() -> list:
         return all_items
 
 
-async def post_kev_update():
+async def post_kev_update(settings: Config = None):
     """Fetch and post KEV updates."""
-    # Get secrets
-    token = get_secret('DISCORD', 'BOT_TOKEN')
-    if not token:
-        token = os.getenv('DISCORD_BOT_TOKEN') or os.getenv('DISCORD_TOKEN')
-    
-    if not token:
-        logger.error("DISCORD_TOKEN not found")
-        return False
-    
-    channel_id_str = get_secret('NEWS', 'KEV_CHANNEL_ID')
-    if not channel_id_str:
-        channel_id_str = os.getenv('NEWS_KEV_CHANNEL_ID')
-    
-    if not channel_id_str:
+    # Token and channel id come validated from the typed config; a
+    # malformed id is refused in main() before we get here.
+    if settings is None:
+        settings = load_config()
+    token = settings.discord.bot_token.reveal()
+    channel_id = settings.news.kev
+    if channel_id is None:
         logger.error("NEWS_KEV_CHANNEL_ID not set")
-        return False
-    
-    try:
-        channel_id = int(channel_id_str)
-    except ValueError:
-        logger.error("Invalid NEWS_KEV_CHANNEL_ID (not numeric)")
         return False
     
     # Load state
@@ -354,7 +341,12 @@ async def post_kev_update():
 if __name__ == '__main__':
     logger.info("KEV runner starting...")
     try:
-        asyncio.run(post_kev_update())
+        settings = load_config()
+    except ConfigError as e:
+        logger.error("Refusing to run:\n%s", e)
+        sys.exit(1)
+    try:
+        asyncio.run(post_kev_update(settings))
         logger.info("KEV runner completed")
         sys.exit(0)
     except Exception as e:

--- a/penguin-overlord/news_runner.py
+++ b/penguin-overlord/news_runner.py
@@ -26,7 +26,6 @@ Usage:
 """
 
 import sys
-import os
 import argparse
 import asyncio
 import logging
@@ -43,7 +42,7 @@ import discord
 from discord.ext import commands
 from utils.news_fetcher import OptimizedNewsFetcher
 from utils.logging_setup import configure_logging
-from utils.secrets import get_secret
+from utils.config import Config, ConfigError, load_config
 
 # INFO by default; --verbose (or LOG_LEVEL=DEBUG) turns on the HTML-stripping
 # detail this used to log unconditionally, on every timer run, forever.
@@ -53,9 +52,11 @@ logger = configure_logging('news_runner')
 class StandaloneNewsRunner:
     """Standalone news fetcher and poster."""
     
-    def __init__(self, category: str):
+    def __init__(self, category: str, settings: Config = None):
         self.category = category
         self.project_root = Path(__file__).parent.parent / "penguin-overlord"
+        # Typed environment (token, channel ids); validated once in main().
+        self.settings = settings or load_config()
         self.config = self._load_config()
         
         # Use /app/data for cache (mounted volume) instead of /app/penguin-overlord/data
@@ -85,16 +86,10 @@ class StandaloneNewsRunner:
             except Exception as e:
                 logger.error(f"Failed to load config: {e}")
         
-        # Override channel_id from secrets manager (Doppler/AWS/Vault) or environment
-        # Try secrets manager first (Doppler recommended for production)
-        channel_id_str = get_secret('NEWS', f'{self.category.upper()}_CHANNEL_ID')
-        
-        # Fallback to direct env var if not in secrets manager
-        if not channel_id_str:
-            env_var_name = f"NEWS_{self.category.upper()}_CHANNEL_ID"
-            channel_id_str = os.getenv(env_var_name)
-        
-        if channel_id_str and str(channel_id_str).isdigit():
+        # NEWS_<CATEGORY>_CHANNEL_ID from the secrets manager or environment
+        # (already validated as a Discord id) overrides the JSON file.
+        channel_id = self.settings.news.channel_id(self.category)
+        if channel_id is not None:
             logger.info(f"Using channel ID from secrets for {self.category}")
             # Ensure category exists in config
             if self.category not in config:
@@ -105,7 +100,7 @@ class StandaloneNewsRunner:
                     'sources': {},
                     'concurrency_limit': 5
                 }
-            config[self.category]['channel_id'] = int(channel_id_str)
+            config[self.category]['channel_id'] = channel_id
             # Auto-enable if channel is set (for fresh installs)
             if not config[self.category].get('enabled'):
                 config[self.category]['enabled'] = True
@@ -167,16 +162,8 @@ class StandaloneNewsRunner:
             logger.warning(f"No channel configured for {self.category}")
             return
         
-        # Load bot token from secrets manager (Doppler/AWS/Vault) or env
-        token = get_secret('DISCORD', 'BOT_TOKEN')
-        if not token:
-            # Fallback to direct env var
-            token = os.getenv('DISCORD_BOT_TOKEN') or os.getenv('DISCORD_TOKEN')
-        
-        if not token:
-            logger.error("No Discord token found in secrets or environment")
-            return
-        
+        token = self.settings.discord.bot_token.reveal()
+
         # Get sources
         all_sources = self._get_sources()
         if not all_sources:
@@ -277,8 +264,14 @@ async def main():
         configure_logging('news_runner', level=logging.DEBUG)
 
     logger.info(f"Starting news runner for category: {args.category}")
-    
-    runner = StandaloneNewsRunner(args.category)
+
+    try:
+        settings = load_config()
+    except ConfigError as e:
+        logger.error("Refusing to run:\n%s", e)
+        sys.exit(1)
+
+    runner = StandaloneNewsRunner(args.category, settings)
     await runner.fetch_and_post()
     
     logger.info(f"News runner completed for {args.category}")

--- a/penguin-overlord/solar_runner.py
+++ b/penguin-overlord/solar_runner.py
@@ -14,7 +14,7 @@ Runs independently of the main bot process for reliability.
 Usage:
     python solar_runner.py
     
-Environment Variables:
+Environment Variables (validated by utils.config at startup):
     DISCORD_BOT_TOKEN - Required (supports Doppler via get_secret)
     SOLAR_POST_CHANNEL_ID - Required (channel ID for posting)
 """
@@ -305,8 +305,7 @@ def predict_band_conditions(band_mhz, band_name, fof2, muf_nvis, muf_regional, m
 # Load environment
 load_dotenv()
 
-# Import secrets utility
-from utils.secrets import get_secret
+from utils.config import Config, ConfigError, load_config
 from utils.logging_setup import configure_logging
 from utils.state import load_json_state, save_json_state
 
@@ -405,23 +404,16 @@ async def fetch_solar_data(session: aiohttp.ClientSession) -> dict | None:
     return None
 
 
-async def post_solar_update():
+async def post_solar_update(settings: Config = None):
     """Fetch and post solar/propagation update."""
-    token = get_secret('DISCORD', 'BOT_TOKEN')
-    channel_id = get_secret('SOLAR', 'POST_CHANNEL_ID')
-    
-    if not token:
-        logger.error("DISCORD_BOT_TOKEN not set")
-        return False
-    
-    if not channel_id:
+    # Token and channel id come validated from the typed config; a
+    # malformed id is refused in __main__ before we get here.
+    if settings is None:
+        settings = load_config()
+    token = settings.discord.bot_token.reveal()
+    channel_id = settings.posting.solar_channel_id
+    if channel_id is None:
         logger.error("SOLAR_POST_CHANNEL_ID not set")
-        return False
-    
-    try:
-        channel_id = int(channel_id)
-    except ValueError:
-        logger.error("Invalid SOLAR_POST_CHANNEL_ID (not numeric)")
         return False
     
     # Create Discord client
@@ -493,7 +485,12 @@ async def post_solar_update():
 if __name__ == '__main__':
     logger.info("Solar runner starting...")
     try:
-        asyncio.run(post_solar_update())
+        settings = load_config()
+    except ConfigError as e:
+        logger.error("Refusing to run:\n%s", e)
+        sys.exit(1)
+    try:
+        asyncio.run(post_solar_update(settings))
         logger.info("Solar runner completed")
         sys.exit(0)
     except Exception as e:

--- a/penguin-overlord/utils/config.py
+++ b/penguin-overlord/utils/config.py
@@ -1,0 +1,865 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Typed configuration, loaded and validated once at startup.
+
+Before this module every feature read its own `os.getenv` calls, so a typo
+in one channel id surfaced hours later as a silent no-post, and a missing
+token produced a different error in each of the six entry points. Now
+`load_config()` reads the whole environment in one pass, parses each value
+into its real type, and raises a single `ConfigError` that lists every
+missing or malformed variable together with what was expected.
+
+Design rules:
+
+- Stdlib only (dataclasses), no pydantic: this module is a prerequisite
+  for the repo split and the Kubernetes deployment, and it must import
+  cleanly in every process, runners included.
+- `env` is a parameter. Tests pass a plain dict and never touch the real
+  environment or a .env file.
+- Anything with a secrets-manager platform (DISCORD_*, NEWS_*, MOD_*,
+  WELCOME_*, ...) is resolved through `utils.secrets.get_secret`, exactly
+  as the cogs do today, so Doppler/AWS/Vault keep overriding .env.
+- Secret values are wrapped in `Secret`, which redacts itself in repr and
+  str. Error messages name the variable and the expected shape; they only
+  echo the offending value for non-secret variables, and truncated.
+- Optional features default OFF. The one required variable is the bot
+  token.
+
+The section loaders (`load_logging_config`, `load_metrics_config`,
+`load_paths_config`) exist for the few module-level reads that must happen
+before `load_config()` can run (logging has to exist to report the
+config error; metrics and the runners' DATA_DIR are import-time constants).
+They substitute defaults for anything malformed and never raise; the same
+malformed value is then reported by `load_config()` at startup.
+
+Adding a variable: give its section dataclass a typed field with a
+default, read it in that section's `_load_*` function with the matching
+`_Reader` method, document it in docs/reference/CONFIGURATION.md and
+.env.example, and add a line to tests/unit/test_config.py.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Callable, Mapping, Optional
+
+# ---------------------------------------------------------------------------
+# Public constants
+# ---------------------------------------------------------------------------
+
+NEWS_CATEGORIES = (
+    'cybersecurity', 'tech', 'gaming', 'apple_google', 'cve', 'kev',
+    'us_legislation', 'eu_legislation', 'uk_legislation', 'general_news',
+    'vendor_alerts',
+)
+
+# Feature names ai/config.py knows about; each gets AI_<FEATURE>_* overrides.
+AI_FEATURES = ('roasting', 'moderation', 'news', 'cve', 'legislation')
+
+# Variables whose prefix is a get_secret() platform. Everything else is
+# plain environment. Mirrors the per-cog _env() helpers, which consult the
+# secrets manager for exactly these prefixes.
+_SECRET_PLATFORMS = ('DISCORD', 'NEWS', 'XKCD', 'COMIC', 'SOLAR', 'MOD',
+                     'HELPER', 'WELCOME', 'AI', 'GEMINI')
+
+DEFAULT_LOG_MAX_BYTES = 10 * 1024 * 1024
+DEFAULT_LOG_BACKUPS = 5
+
+_SNOWFLAKE_RE = re.compile(r'\d{17,20}')
+_TIME_RE = re.compile(r'^(\d{1,2}):(\d{2})$')
+_TRUE = ('1', 'true', 'yes', 'on')
+_FALSE = ('0', 'false', 'no', 'off')
+
+SecretLookup = Callable[[str, str], Optional[str]]
+
+
+# ---------------------------------------------------------------------------
+# Secret wrapper and error type
+# ---------------------------------------------------------------------------
+
+class Secret:
+    """A string that will not print itself. Call `.reveal()` to use it."""
+
+    __slots__ = ('_value',)
+
+    def __init__(self, value: str):
+        self._value = value
+
+    def reveal(self) -> str:
+        return self._value
+
+    def __bool__(self) -> bool:
+        return bool(self._value)
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, Secret) and other._value == self._value
+
+    def __hash__(self) -> int:
+        return hash(self._value)
+
+    def __repr__(self) -> str:
+        return 'Secret(***)'
+
+    __str__ = __repr__
+
+
+class ConfigError(ValueError):
+    """Raised by load_config() with every problem found, not just the first."""
+
+    def __init__(self, problems: list[str]):
+        self.problems = list(problems)
+        count = len(self.problems)
+        noun = 'problem' if count == 1 else 'problems'
+        lines = [f'{count} configuration {noun}:']
+        lines.extend(f'  - {p}' for p in self.problems)
+        super().__init__('\n'.join(lines))
+
+
+# ---------------------------------------------------------------------------
+# Section dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class DiscordConfig:
+    bot_token: Secret = field(repr=False, default=Secret(''))
+    owner_id: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class LoggingConfig:
+    level: int = logging.INFO
+    file: Optional[str] = None
+    max_bytes: int = DEFAULT_LOG_MAX_BYTES
+    backups: int = DEFAULT_LOG_BACKUPS
+
+
+@dataclass(frozen=True)
+class PathsConfig:
+    data_dir: Path = Path('data')
+    database_path: Path = Path('data/penguin_overlord.db')
+    xkcd_state_path: Path = Path('data/xkcd_state.json')
+    comic_state_path: Path = Path('data/comic_state.json')
+
+
+@dataclass(frozen=True)
+class NewsConfig:
+    cybersecurity: Optional[int] = None
+    tech: Optional[int] = None
+    gaming: Optional[int] = None
+    apple_google: Optional[int] = None
+    cve: Optional[int] = None
+    kev: Optional[int] = None
+    us_legislation: Optional[int] = None
+    eu_legislation: Optional[int] = None
+    uk_legislation: Optional[int] = None
+    general_news: Optional[int] = None
+    vendor_alerts: Optional[int] = None
+    # NEWS_AUTO_POST: in-bot posting loops; off where systemd timers own it.
+    auto_post: bool = True
+
+    def channel_id(self, category: str) -> Optional[int]:
+        if category not in NEWS_CATEGORIES:
+            raise KeyError(f'unknown news category: {category}')
+        return getattr(self, category)
+
+    def configured(self) -> int:
+        return sum(1 for c in NEWS_CATEGORIES if getattr(self, c) is not None)
+
+
+@dataclass(frozen=True)
+class PostingConfig:
+    """The three one-shot posters (xkcd, daily comic, solar report)."""
+    xkcd_channel_id: Optional[int] = None
+    xkcd_poll_interval_minutes: int = 30
+    comic_channel_id: Optional[int] = None
+    solar_channel_id: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class MetricsConfig:
+    enabled: bool = False
+    port: int = 9200
+
+
+@dataclass(frozen=True)
+class AiFeatureConfig:
+    """Per-feature AI_<FEATURE>_* overrides; None means inherit the default."""
+    enabled: bool = False
+    model: Optional[str] = None
+    ollama_host: Optional[str] = None
+    temperature: Optional[float] = None
+    max_tokens: Optional[int] = None
+    timeout: Optional[float] = None
+    gemini_fallback: Optional[bool] = None
+
+
+@dataclass(frozen=True)
+class AiConfig:
+    enabled: bool = False
+    ollama_host: str = 'http://localhost:11434'
+    default_model: str = 'llama3.2'
+    default_temperature: float = 0.7
+    default_max_tokens: int = 256
+    default_timeout: float = 30.0
+    gemini_api_key: Optional[Secret] = field(repr=False, default=None)
+    gemini_fallback: bool = False
+    gemini_model: str = 'gemini-2.0-flash'
+    max_concurrent_requests: int = 2
+    max_pending_requests: int = 20
+    min_delay_between_requests: float = 0.5
+    max_retries: int = 2
+    retry_delay_base: float = 2.0
+    reconnect_interval: float = 60.0
+    features: Mapping[str, AiFeatureConfig] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class ModerationConfig:
+    enabled: bool = False
+    dry_run: bool = True
+    auto_delete: bool = False
+    auto_timeout: bool = False
+    min_confidence: float = 0.75
+    alert_min_confidence: float = 0.0
+    ignored_categories: frozenset[str] = frozenset()
+    timeout_minutes: int = 10
+    min_message_length: int = 6
+    user_cooldown_seconds: float = 20.0
+    retention_days: int = 90
+    alert_channel_id: Optional[int] = None
+    ping_role_id: Optional[int] = None
+    channels: frozenset[int] = frozenset()
+    ignored_roles: frozenset[int] = frozenset()
+    trusted_roles: frozenset[int] = frozenset()
+    creator_roles: frozenset[int] = frozenset()
+    member_days: int = 30
+    veteran_days: int = 365
+    reclaimed_tiers: frozenset[str] = frozenset({'veteran', 'trusted', 'creator'})
+    profile: tuple[str, ...] = ('general',)
+    review_votes: int = 1
+    leniency_max_confidence: float = 0.95
+    rules_channel_id: Optional[int] = None
+    rules_sync_hours: float = 24.0
+    # Second-stage model (ai/features/moderation.py).
+    second_model: Optional[str] = None
+    second_categories: frozenset[str] = frozenset({'hate_speech', 'harassment'})
+    second_min_confidence: float = 0.85
+
+
+@dataclass(frozen=True)
+class GreeterConfig:
+    enabled: bool = False
+    max_mentions: int = 12
+    channel_id: Optional[int] = None
+    verify_channel_id: Optional[int] = None
+    rules_channel_id: Optional[int] = None
+    roles_channel_id: Optional[int] = None
+    resource_channel_id: Optional[int] = None
+    wagon_channel_id: Optional[int] = None
+    general_channel_id: Optional[int] = None
+    role_id: Optional[int] = None
+    timezone: str = 'UTC'
+    retract_window_seconds: float = 86400.0
+    join_enabled: bool = True
+    join_channel_id: Optional[int] = None
+    join_message: Optional[str] = None
+    join_image: Optional[str] = None
+    join_cooldown_seconds: float = 900.0
+    join_remind_after_seconds: float = 300.0
+    join_daily_at: Optional[tuple[int, int]] = None
+    verify_enabled: bool = True
+    verify_message: Optional[str] = None
+    verify_image: Optional[str] = None
+    verify_cooldown_seconds: float = 10800.0
+    max_tenure_days: float = 30.0
+    verify_daily_at: Optional[tuple[int, int]] = None
+
+
+@dataclass(frozen=True)
+class HelperConfig:
+    enabled: bool = False
+    channels: frozenset[int] = frozenset()
+    tiers: frozenset[str] = frozenset({'new'})
+    cooldown_seconds: float = 60.0
+    user_cooldown_seconds: float = 1800.0
+    min_length: int = 12
+    use_llm: bool = True
+    resource_channel_id: Optional[int] = None
+    rules_channel_id: Optional[int] = None
+    message: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class RolePickerConfig:
+    enabled: bool = False
+
+
+@dataclass(frozen=True)
+class ProfileScreenConfig:
+    enabled: bool = False
+    use_llm: bool = True
+    hold_greeting: bool = True
+    protected_names: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class SkidDetectorConfig:
+    enabled: bool = True
+    fire_chance: float = 0.30
+    cooldown_seconds: float = 180.0
+    llm: bool = False
+
+
+@dataclass(frozen=True)
+class BanterConfig:
+    arch_llm: bool = False
+
+
+@dataclass(frozen=True)
+class Config:
+    discord: DiscordConfig = field(default_factory=DiscordConfig)
+    logging: LoggingConfig = field(default_factory=LoggingConfig)
+    paths: PathsConfig = field(default_factory=PathsConfig)
+    news: NewsConfig = field(default_factory=NewsConfig)
+    posting: PostingConfig = field(default_factory=PostingConfig)
+    metrics: MetricsConfig = field(default_factory=MetricsConfig)
+    ai: AiConfig = field(default_factory=AiConfig)
+    moderation: ModerationConfig = field(default_factory=ModerationConfig)
+    greeter: GreeterConfig = field(default_factory=GreeterConfig)
+    helper: HelperConfig = field(default_factory=HelperConfig)
+    role_picker: RolePickerConfig = field(default_factory=RolePickerConfig)
+    profile_screen: ProfileScreenConfig = field(default_factory=ProfileScreenConfig)
+    skid_detector: SkidDetectorConfig = field(default_factory=SkidDetectorConfig)
+    banter: BanterConfig = field(default_factory=BanterConfig)
+
+
+# ---------------------------------------------------------------------------
+# Reader: one place that knows how to turn a raw string into a typed value
+# and how to phrase the complaint when it cannot.
+# ---------------------------------------------------------------------------
+
+def _platform_for(name: str) -> Optional[str]:
+    for platform in _SECRET_PLATFORMS:
+        if name.startswith(platform + '_'):
+            return platform
+    return None
+
+
+def _is_placeholder(value: str) -> bool:
+    # .env.example ships `your_bot_token_here` style values; bot.py has
+    # always treated those as unset rather than as garbage.
+    return value.lower().startswith('your_')
+
+
+def _show(value: str, limit: int = 32) -> str:
+    """Quote a non-secret value for an error line, truncated so a secret
+    pasted into the wrong variable is never echoed whole."""
+    if len(value) > limit:
+        return repr(value[:limit] + '...')
+    return repr(value)
+
+
+def _split(raw: str, lower: bool) -> list[str]:
+    parts = [p.strip() for p in raw.split(',')]
+    parts = [p for p in parts if p]
+    return [p.lower() for p in parts] if lower else parts
+
+
+class _Reader:
+    def __init__(self, env: Mapping[str, str], secrets: Optional[SecretLookup]):
+        self.env = env
+        self.secrets = secrets
+        self.problems: list[str] = []
+
+    # -- raw access ---------------------------------------------------------
+
+    def raw(self, name: str) -> Optional[str]:
+        """The trimmed value, or None when unset, blank, or a placeholder.
+
+        Secrets-manager platforms are consulted first so Doppler/AWS/Vault
+        keep overriding .env, matching get_secret()'s own priority.
+        """
+        value = None
+        platform = _platform_for(name)
+        if platform and self.secrets is not None:
+            value = self.secrets(platform, name[len(platform) + 1:])
+        if not value:
+            value = self.env.get(name)
+        if value is None:
+            return None
+        value = str(value).strip()
+        if not value or _is_placeholder(value):
+            return None
+        return value
+
+    def fail(self, name: str, expected: str, value: Optional[str] = None) -> None:
+        if value is None:
+            self.problems.append(f'{name}: {expected}')
+        else:
+            self.problems.append(f'{name}: {expected}, got {_show(value)}')
+
+    # -- typed parsers ------------------------------------------------------
+
+    def str(self, name: str, default: Optional[str] = None) -> Optional[str]:
+        value = self.raw(name)
+        return default if value is None else value
+
+    def secret(self, name: str, *, required: bool = False, aliases: tuple[str, ...] = ()) -> Optional[Secret]:
+        value = self.raw(name)
+        for alias in aliases:
+            if value:
+                break
+            value = self.raw(alias)
+        if value:
+            return Secret(value)
+        if required:
+            # Never a value here, by construction: a secret is either
+            # present or absent, and this line is the only thing logged.
+            self.fail(name, 'required, not set (environment, .env, or a secrets manager; see .env.example)')
+        return None
+
+    def bool(self, name: str, default: bool) -> bool:
+        value = self.raw(name)
+        if value is None:
+            return default
+        lowered = value.lower()
+        if lowered in _TRUE:
+            return True
+        if lowered in _FALSE:
+            return False
+        self.fail(name, 'expected true/false (also 1/0, yes/no, on/off)', value)
+        return default
+
+    def int(self, name: str, default: int, *, minimum: Optional[int] = None,
+            maximum: Optional[int] = None) -> int:
+        value = self.raw(name)
+        if value is None:
+            return default
+        try:
+            parsed = int(value)
+        except ValueError:
+            self.fail(name, 'expected an integer', value)
+            return default
+        if minimum is not None and parsed < minimum:
+            self.fail(name, f'expected an integer >= {minimum}', value)
+            return default
+        if maximum is not None and parsed > maximum:
+            self.fail(name, f'expected an integer <= {maximum}', value)
+            return default
+        return parsed
+
+    def optional_int(self, name: str) -> Optional[int]:
+        value = self.raw(name)
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except ValueError:
+            self.fail(name, 'expected an integer', value)
+            return None
+
+    def float(self, name: str, default: float) -> float:
+        value = self.raw(name)
+        if value is None:
+            return default
+        try:
+            return float(value)
+        except ValueError:
+            self.fail(name, 'expected a number', value)
+            return default
+
+    def optional_float(self, name: str) -> Optional[float]:
+        value = self.raw(name)
+        if value is None:
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            self.fail(name, 'expected a number', value)
+            return None
+
+    def optional_bool(self, name: str) -> Optional[bool]:
+        if self.raw(name) is None:
+            return None
+        return self.bool(name, False)
+
+    def snowflake(self, name: str) -> Optional[int]:
+        """A Discord id: 17 to 20 digits. `<#id>`, `<@id>`, `<@&id>` and
+        quoted ids are unwrapped (the runners accepted those)."""
+        value = self.raw(name)
+        if value is None:
+            return None
+        parsed = self._snowflake(value)
+        if parsed is None:
+            self.fail(name, 'expected a Discord id (17 to 20 digits)', value)
+        return parsed
+
+    def snowflakes(self, name: str) -> frozenset[int]:
+        """Comma or whitespace separated Discord ids."""
+        value = self.raw(name)
+        if value is None:
+            return frozenset()
+        ids = set()
+        for part in re.split(r'[,\s]+', value):
+            if not part:
+                continue
+            parsed = self._snowflake(part)
+            if parsed is None:
+                self.fail(name, 'expected comma-separated Discord ids (17 to 20 digits each)', part)
+                continue
+            ids.add(parsed)
+        return frozenset(ids)
+
+    @staticmethod
+    def _snowflake(value: str) -> Optional[int]:
+        stripped = value.strip().strip('"\'')
+        if stripped.startswith('<') and stripped.endswith('>'):
+            stripped = stripped[1:-1].lstrip('#@&!')
+        return int(stripped) if _SNOWFLAKE_RE.fullmatch(stripped) else None
+
+    def words(self, name: str, default: tuple[str, ...] = (), *, lower: bool = True) -> tuple[str, ...]:
+        value = self.raw(name)
+        if value is None:
+            return default
+        return tuple(_split(value, lower))
+
+    def time(self, name: str) -> Optional[tuple[int, int]]:
+        value = self.raw(name)
+        if value is None:
+            return None
+        match = _TIME_RE.match(value)
+        if match and int(match[1]) <= 23 and int(match[2]) <= 59:
+            return (int(match[1]), int(match[2]))
+        self.fail(name, 'expected a time of day as HH:MM (24-hour)', value)
+        return None
+
+    def timezone(self, name: str, default: str = 'UTC') -> str:
+        value = self.raw(name)
+        if value is None:
+            return default
+        from zoneinfo import ZoneInfo
+        try:
+            ZoneInfo(value)
+        except Exception:
+            self.fail(name, 'expected an IANA timezone name such as America/New_York', value)
+            return default
+        return value
+
+    def level(self, name: str, default: int = logging.INFO) -> int:
+        value = self.raw(name)
+        if value is None:
+            return default
+        resolved = logging.getLevelName(value.upper())
+        if isinstance(resolved, int):
+            return resolved
+        self.fail(name, 'expected a log level: DEBUG, INFO, WARNING, ERROR or CRITICAL', value)
+        return default
+
+    def path(self, name: str, default: Path) -> Path:
+        value = self.raw(name)
+        return default if value is None else Path(value)
+
+
+# ---------------------------------------------------------------------------
+# Section loaders
+# ---------------------------------------------------------------------------
+
+def _load_discord(r: _Reader) -> DiscordConfig:
+    return DiscordConfig(
+        bot_token=r.secret('DISCORD_BOT_TOKEN', required=True, aliases=('DISCORD_TOKEN',)) or Secret(''),
+        owner_id=r.snowflake('DISCORD_OWNER_ID'),
+    )
+
+
+def _load_logging(r: _Reader) -> LoggingConfig:
+    return LoggingConfig(
+        level=r.level('LOG_LEVEL'),
+        file=r.str('LOG_FILE'),
+        max_bytes=r.int('LOG_MAX_BYTES', DEFAULT_LOG_MAX_BYTES, minimum=1),
+        backups=r.int('LOG_BACKUPS', DEFAULT_LOG_BACKUPS, minimum=0),
+    )
+
+
+def _default_data_dir() -> Path:
+    # Same order as utils.state.resolve_data_dir: DATA_DIR, then the Docker
+    # volume mount, then ./data relative to the working directory.
+    return Path('/app/data') if os.path.exists('/app/data') else Path('data')
+
+
+def _load_paths(r: _Reader) -> PathsConfig:
+    data_dir = r.path('DATA_DIR', _default_data_dir())
+    return PathsConfig(
+        data_dir=data_dir,
+        database_path=r.path('BOT_DATABASE_PATH', data_dir / 'penguin_overlord.db'),
+        xkcd_state_path=r.path('XKCD_STATE_PATH', data_dir / 'xkcd_state.json'),
+        comic_state_path=r.path('COMIC_STATE_PATH', data_dir / 'comic_state.json'),
+    )
+
+
+def _load_news(r: _Reader) -> NewsConfig:
+    channels = {c: r.snowflake(f'NEWS_{c.upper()}_CHANNEL_ID') for c in NEWS_CATEGORIES}
+    return NewsConfig(auto_post=r.bool('NEWS_AUTO_POST', True), **channels)
+
+
+def _load_posting(r: _Reader) -> PostingConfig:
+    return PostingConfig(
+        xkcd_channel_id=r.snowflake('XKCD_POST_CHANNEL_ID'),
+        xkcd_poll_interval_minutes=r.int('XKCD_POLL_INTERVAL_MINUTES', 30, minimum=1),
+        comic_channel_id=r.snowflake('COMIC_POST_CHANNEL_ID'),
+        solar_channel_id=r.snowflake('SOLAR_POST_CHANNEL_ID'),
+    )
+
+
+def _load_metrics(r: _Reader) -> MetricsConfig:
+    return MetricsConfig(
+        enabled=r.bool('METRICS_ENABLED', False),
+        port=r.int('METRICS_PORT', 9200, minimum=1, maximum=65535),
+    )
+
+
+def _load_ai(r: _Reader) -> AiConfig:
+    # Same resolution as ai/config.py: AI_DEFAULT_OLLAMA_HOST or OLLAMA_HOST,
+    # scheme-less values get http:// and OLLAMA_PORT (default 11434).
+    host = r.str('AI_DEFAULT_OLLAMA_HOST') or r.str('OLLAMA_HOST')
+    if host and '://' not in host:
+        host = f"http://{host}:{r.str('OLLAMA_PORT', '11434')}"
+    features = {}
+    for feature in AI_FEATURES:
+        prefix = f'AI_{feature.upper()}'
+        features[feature] = AiFeatureConfig(
+            enabled=r.bool(f'{prefix}_ENABLED', False),
+            model=r.str(f'{prefix}_MODEL'),
+            ollama_host=r.str(f'{prefix}_OLLAMA_HOST'),
+            temperature=r.optional_float(f'{prefix}_TEMPERATURE'),
+            max_tokens=r.optional_int(f'{prefix}_MAX_TOKENS'),
+            timeout=r.optional_float(f'{prefix}_TIMEOUT'),
+            gemini_fallback=r.optional_bool(f'{prefix}_GEMINI_FALLBACK'),
+        )
+    return AiConfig(
+        enabled=r.bool('AI_ENABLED', False),
+        ollama_host=host or 'http://localhost:11434',
+        default_model=r.str('AI_DEFAULT_MODEL') or r.str('OLLAMA_MODEL') or 'llama3.2',
+        default_temperature=r.float('AI_DEFAULT_TEMPERATURE', 0.7),
+        default_max_tokens=r.int('AI_DEFAULT_MAX_TOKENS', 256),
+        default_timeout=r.float('AI_DEFAULT_TIMEOUT', 30.0),
+        gemini_api_key=r.secret('GEMINI_API_KEY'),
+        gemini_fallback=r.bool('AI_GEMINI_FALLBACK', False),
+        gemini_model=r.str('AI_GEMINI_MODEL', 'gemini-2.0-flash'),
+        max_concurrent_requests=r.int('AI_MAX_CONCURRENT_REQUESTS', 2, minimum=1),
+        max_pending_requests=r.int('AI_MAX_PENDING_REQUESTS', 20, minimum=0),
+        min_delay_between_requests=r.float('AI_MIN_DELAY_BETWEEN_REQUESTS', 0.5),
+        max_retries=r.int('AI_MAX_RETRIES', 2, minimum=0),
+        retry_delay_base=r.float('AI_RETRY_DELAY_BASE', 2.0),
+        reconnect_interval=r.float('AI_RECONNECT_INTERVAL', 60.0),
+        features=features,
+    )
+
+
+def _load_moderation(r: _Reader) -> ModerationConfig:
+    return ModerationConfig(
+        enabled=r.bool('MOD_ENABLED', False),
+        dry_run=r.bool('MOD_DRY_RUN', True),
+        auto_delete=r.bool('MOD_AUTO_DELETE', False),
+        auto_timeout=r.bool('MOD_AUTO_TIMEOUT', False),
+        min_confidence=r.float('MOD_MIN_CONFIDENCE', 0.75),
+        alert_min_confidence=r.float('MOD_ALERT_MIN_CONFIDENCE', 0.0),
+        ignored_categories=frozenset(r.words('MOD_IGNORED_CATEGORIES')),
+        timeout_minutes=r.int('MOD_TIMEOUT_MINUTES', 10),
+        min_message_length=r.int('MOD_MIN_MESSAGE_LENGTH', 6),
+        user_cooldown_seconds=r.float('MOD_USER_COOLDOWN_SECONDS', 20.0),
+        retention_days=r.int('MOD_RETENTION_DAYS', 90),
+        alert_channel_id=r.snowflake('MOD_ALERT_CHANNEL_ID'),
+        ping_role_id=r.snowflake('MOD_PING_ROLE_ID'),
+        channels=r.snowflakes('MOD_CHANNELS'),
+        ignored_roles=r.snowflakes('MOD_IGNORED_ROLES'),
+        trusted_roles=r.snowflakes('MOD_TRUSTED_ROLES'),
+        creator_roles=r.snowflakes('MOD_CREATOR_ROLES'),
+        member_days=r.int('MOD_MEMBER_DAYS', 30),
+        veteran_days=r.int('MOD_VETERAN_DAYS', 365),
+        reclaimed_tiers=frozenset(r.words('MOD_RECLAIMED_TIERS', ('veteran', 'trusted', 'creator'))),
+        profile=r.words('MOD_PROFILE', ('general',)),
+        review_votes=r.int('MOD_REVIEW_VOTES', 1, minimum=1),
+        leniency_max_confidence=r.float('MOD_LENIENCY_MAX_CONFIDENCE', 0.95),
+        rules_channel_id=r.snowflake('MOD_RULES_CHANNEL_ID'),
+        rules_sync_hours=r.float('MOD_RULES_SYNC_HOURS', 24.0),
+        second_model=r.str('AI_MODERATION_SECOND_MODEL'),
+        second_categories=frozenset(r.words('AI_MODERATION_SECOND_CATEGORIES', ('hate_speech', 'harassment'))),
+        second_min_confidence=r.float('AI_MODERATION_SECOND_MIN_CONFIDENCE', 0.85),
+    )
+
+
+def _load_greeter(r: _Reader) -> GreeterConfig:
+    return GreeterConfig(
+        enabled=r.bool('WELCOME_ENABLED', False),
+        max_mentions=r.int('WELCOME_MAX_MENTIONS', 12, minimum=1),
+        channel_id=r.snowflake('WELCOME_CHANNEL_ID'),
+        verify_channel_id=r.snowflake('WELCOME_VERIFY_CHANNEL_ID'),
+        rules_channel_id=r.snowflake('WELCOME_RULES_CHANNEL_ID'),
+        roles_channel_id=r.snowflake('WELCOME_ROLES_CHANNEL_ID'),
+        resource_channel_id=r.snowflake('WELCOME_RESOURCE_CHANNEL_ID'),
+        wagon_channel_id=r.snowflake('WELCOME_WAGON_CHANNEL_ID'),
+        general_channel_id=r.snowflake('WELCOME_GENERAL_CHANNEL_ID'),
+        role_id=r.snowflake('WELCOME_ROLE_ID'),
+        timezone=r.timezone('WELCOME_TIMEZONE'),
+        retract_window_seconds=r.float('WELCOME_RETRACT_WINDOW_SECONDS', 86400.0),
+        join_enabled=r.bool('WELCOME_JOIN_ENABLED', True),
+        join_channel_id=r.snowflake('WELCOME_JOIN_CHANNEL_ID'),
+        join_message=r.str('WELCOME_JOIN_MESSAGE'),
+        join_image=r.str('WELCOME_JOIN_IMAGE'),
+        join_cooldown_seconds=r.float('WELCOME_JOIN_COOLDOWN_SECONDS', 900.0),
+        join_remind_after_seconds=r.float('WELCOME_JOIN_REMIND_AFTER_SECONDS', 300.0),
+        join_daily_at=r.time('WELCOME_JOIN_DAILY_AT'),
+        verify_enabled=r.bool('WELCOME_VERIFY_ENABLED', True),
+        verify_message=r.str('WELCOME_VERIFY_MESSAGE'),
+        verify_image=r.str('WELCOME_VERIFY_IMAGE'),
+        verify_cooldown_seconds=r.float('WELCOME_VERIFY_COOLDOWN_SECONDS', 10800.0),
+        max_tenure_days=r.float('WELCOME_MAX_TENURE_DAYS', 30.0),
+        verify_daily_at=r.time('WELCOME_VERIFY_DAILY_AT'),
+    )
+
+
+def _load_helper(r: _Reader) -> HelperConfig:
+    return HelperConfig(
+        enabled=r.bool('HELPER_ENABLED', False),
+        channels=r.snowflakes('HELPER_CHANNELS'),
+        tiers=frozenset(r.words('HELPER_TIERS', ('new',))),
+        cooldown_seconds=r.float('HELPER_COOLDOWN_SECONDS', 60.0),
+        user_cooldown_seconds=r.float('HELPER_USER_COOLDOWN_SECONDS', 1800.0),
+        min_length=r.int('HELPER_MIN_LENGTH', 12),
+        use_llm=r.bool('HELPER_USE_LLM', True),
+        resource_channel_id=r.snowflake('HELPER_RESOURCE_CHANNEL_ID'),
+        rules_channel_id=r.snowflake('HELPER_RULES_CHANNEL_ID'),
+        message=r.str('HELPER_MESSAGE'),
+    )
+
+
+def _load_role_picker(r: _Reader) -> RolePickerConfig:
+    return RolePickerConfig(enabled=r.bool('ROLE_PICKER_ENABLED', False))
+
+
+def _load_profile_screen(r: _Reader) -> ProfileScreenConfig:
+    return ProfileScreenConfig(
+        enabled=r.bool('PROFILE_SCREEN_ENABLED', False),
+        use_llm=r.bool('PROFILE_SCREEN_LLM', True),
+        hold_greeting=r.bool('PROFILE_SCREEN_HOLD_GREETING', True),
+        protected_names=r.words('PROFILE_SCREEN_PROTECTED_NAMES', lower=False),
+    )
+
+
+def _load_skid_detector(r: _Reader) -> SkidDetectorConfig:
+    return SkidDetectorConfig(
+        enabled=r.bool('SKID_DETECTOR_ENABLED', True),
+        fire_chance=r.float('SKID_FIRE_CHANCE', 0.30),
+        cooldown_seconds=r.float('SKID_COOLDOWN_SECONDS', 180.0),
+        llm=r.bool('SKID_DETECTOR_LLM', False),
+    )
+
+
+def _load_banter(r: _Reader) -> BanterConfig:
+    return BanterConfig(arch_llm=r.bool('ARCH_BANTER_LLM', False))
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+def _reader(env: Optional[Mapping[str, str]], secrets: Optional[SecretLookup], *, use_secrets: bool) -> _Reader:
+    if env is None:
+        env = os.environ
+        if secrets is None and use_secrets:
+            from utils.secrets import get_secret
+            secrets = get_secret
+    return _Reader(env, secrets)
+
+
+def load_config(env: Optional[Mapping[str, str]] = None, *,
+                secrets: Optional[SecretLookup] = None) -> Config:
+    """Load and validate the whole configuration.
+
+    Args:
+        env: the variables to read. None means the real environment
+            (call load_dotenv() first if a .env file should count).
+        secrets: a `(platform, key) -> value | None` lookup consulted before
+            `env` for secrets-manager variables. Defaults to
+            `utils.secrets.get_secret` when `env` is None and to no lookup
+            at all when an explicit `env` is given, so tests stay hermetic.
+
+    Raises:
+        ConfigError: listing every missing or malformed variable at once.
+    """
+    r = _reader(env, secrets, use_secrets=True)
+    config = Config(
+        discord=_load_discord(r),
+        logging=_load_logging(r),
+        paths=_load_paths(r),
+        news=_load_news(r),
+        posting=_load_posting(r),
+        metrics=_load_metrics(r),
+        ai=_load_ai(r),
+        moderation=_load_moderation(r),
+        greeter=_load_greeter(r),
+        helper=_load_helper(r),
+        role_picker=_load_role_picker(r),
+        profile_screen=_load_profile_screen(r),
+        skid_detector=_load_skid_detector(r),
+        banter=_load_banter(r),
+    )
+    if r.problems:
+        raise ConfigError(r.problems)
+    return config
+
+
+def load_logging_config(env: Optional[Mapping[str, str]] = None) -> LoggingConfig:
+    """LOG_* only, defaults substituted for anything malformed; never raises.
+
+    Logging has to exist before load_config() can report its problems, so
+    this is what configure_logging() falls back to. load_config() reports
+    the same bad value afterwards.
+    """
+    return _load_logging(_reader(env, None, use_secrets=False))
+
+
+def load_metrics_config(env: Optional[Mapping[str, str]] = None) -> MetricsConfig:
+    """METRICS_* only, lenient; for utils/metrics.py's import-time constants."""
+    return _load_metrics(_reader(env, None, use_secrets=False))
+
+
+def load_paths_config(env: Optional[Mapping[str, str]] = None) -> PathsConfig:
+    """DATA_DIR and state-file paths only, lenient (it cannot fail today)."""
+    return _load_paths(_reader(env, None, use_secrets=False))
+
+
+def describe_config(config: Config) -> str:
+    """One-line summary for the startup banner and --check-config.
+
+    Counts and on/off flags only: never a value, never an id.
+    """
+    def flag(value: bool) -> str:
+        return 'on' if value else 'off'
+
+    posters = [name for name, channel in (
+        ('xkcd', config.posting.xkcd_channel_id),
+        ('comic', config.posting.comic_channel_id),
+        ('solar', config.posting.solar_channel_id),
+    ) if channel is not None]
+    parts = [
+        f"owner={'set' if config.discord.owner_id else 'unset'}",
+        f'log={logging.getLevelName(config.logging.level)}',
+        f'news={config.news.configured()}/{len(NEWS_CATEGORIES)} channels (auto_post {flag(config.news.auto_post)})',
+        f"posters={','.join(posters) or 'none'}",
+        f'metrics={flag(config.metrics.enabled)}',
+        f'ai={flag(config.ai.enabled)}',
+        f'moderation={flag(config.moderation.enabled)}',
+        f'greeter={flag(config.greeter.enabled)}',
+        f'helper={flag(config.helper.enabled)}',
+        f'role_picker={flag(config.role_picker.enabled)}',
+        f'profile_screen={flag(config.profile_screen.enabled)}',
+        f'skid_detector={flag(config.skid_detector.enabled)}',
+    ]
+    return ' '.join(parts)

--- a/penguin-overlord/utils/logging_setup.py
+++ b/penguin-overlord/utils/logging_setup.py
@@ -25,8 +25,9 @@ set, and stdout logging always stays on so `docker logs` is never empty.
 
 import logging
 import logging.handlers
-import os
 from pathlib import Path
+
+from utils.config import LoggingConfig, load_logging_config
 
 # Third-party loggers that are useful at WARNING and pure noise at INFO.
 # httpx logs a line per request: with two model calls per scanned message
@@ -49,35 +50,33 @@ _DATEFMT = '%Y-%m-%d %H:%M:%S'
 # work instead of stacking duplicates on top of it.
 _OWNED = '_penguin_logging'
 
-DEFAULT_MAX_BYTES = 10 * 1024 * 1024   # 10 MB per file
-DEFAULT_BACKUPS = 5                    # ~60 MB ceiling with the default size
-
-
-def _level(name: str, default: int = logging.INFO) -> int:
-    raw = (os.getenv(name) or '').strip().upper()
-    if not raw:
-        return default
-    resolved = logging.getLevelName(raw)
-    return resolved if isinstance(resolved, int) else default
-
-
-def configure_logging(component: str = 'penguin', *, level: int = None) -> logging.Logger:
+def configure_logging(component: str = 'penguin', *, level: int = None,
+                      settings: LoggingConfig = None) -> logging.Logger:
     """Install stdout logging (plus a rotating file when LOG_FILE is set).
 
-    Env:
+    Env (parsed by utils.config; see LoggingConfig):
         LOG_LEVEL     root level, default INFO (DEBUG/INFO/WARNING/...)
         LOG_FILE      path to also write to; enables in-process rotation
         LOG_MAX_BYTES rotate at this size, default 10 MB
         LOG_BACKUPS   keep this many rotated files, default 5
 
+    `settings` is normally omitted: this runs before load_config() so the
+    config error itself has somewhere to go, and load_logging_config()
+    falls back to defaults for anything malformed (load_config() then
+    reports the bad value properly). Pass `settings` to reuse a loaded
+    Config instead.
+
     Returns the component's logger. Safe to call more than once.
     """
+    if settings is None:
+        settings = load_logging_config()
+
     root = logging.getLogger()
     for handler in [h for h in root.handlers if getattr(h, _OWNED, False)]:
         root.removeHandler(handler)
         handler.close()
 
-    root.setLevel(level if level is not None else _level('LOG_LEVEL'))
+    root.setLevel(level if level is not None else settings.level)
     formatter = logging.Formatter(_FORMAT, datefmt=_DATEFMT)
 
     stream = logging.StreamHandler()
@@ -85,14 +84,14 @@ def configure_logging(component: str = 'penguin', *, level: int = None) -> loggi
     setattr(stream, _OWNED, True)
     root.addHandler(stream)
 
-    log_file = (os.getenv('LOG_FILE') or '').strip()
+    log_file = settings.file
     if log_file:
         try:
             Path(log_file).parent.mkdir(parents=True, exist_ok=True)
             file_handler = logging.handlers.RotatingFileHandler(
                 log_file,
-                maxBytes=int(os.getenv('LOG_MAX_BYTES') or DEFAULT_MAX_BYTES),
-                backupCount=int(os.getenv('LOG_BACKUPS') or DEFAULT_BACKUPS),
+                maxBytes=settings.max_bytes,
+                backupCount=settings.backups,
                 encoding='utf-8',
             )
             file_handler.setFormatter(formatter)

--- a/penguin-overlord/utils/metrics.py
+++ b/penguin-overlord/utils/metrics.py
@@ -14,12 +14,18 @@ whether the Discord gateway is actually up.
 """
 
 import logging
-import os
+
+from utils.config import load_metrics_config
 
 logger = logging.getLogger(__name__)
 
-METRICS_ENABLED = os.getenv('METRICS_ENABLED', 'false').strip().lower() in ('1', 'true', 'yes', 'on')
-METRICS_PORT = int(os.getenv('METRICS_PORT', '9200'))
+# Import-time constants: cogs import this module before any of them could
+# be handed a Config. The section loader is lenient (a bad METRICS_PORT
+# falls back to 9200 here) because bot.py's load_config() has already
+# refused to start on that same value by the time a cog imports us.
+_settings = load_metrics_config()
+METRICS_ENABLED = _settings.enabled
+METRICS_PORT = _settings.port
 
 try:
     from prometheus_client import Counter, Gauge, Histogram, start_http_server

--- a/penguin-overlord/xkcd_runner.py
+++ b/penguin-overlord/xkcd_runner.py
@@ -12,7 +12,7 @@ Runs independently of the main bot process for reliability.
 Usage:
     python xkcd_runner.py
     
-Environment Variables:
+Environment Variables (validated by utils.config at startup):
     DISCORD_BOT_TOKEN - Required (supports Doppler via get_secret)
     XKCD_POST_CHANNEL_ID - Required (channel ID for posting)
 """
@@ -33,8 +33,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 # Load environment
 load_dotenv()
 
-# Import secrets utility
-from utils.secrets import get_secret
+from utils.config import Config, ConfigError, load_config, load_paths_config
 from utils.logging_setup import configure_logging
 from utils.state import load_json_state, save_json_state
 
@@ -43,7 +42,7 @@ logger = configure_logging('xkcd_runner')
 
 
 # Prefer mounted data directory (Docker) or user-specified DATA_DIR, fallback to local data/
-DATA_DIR = os.getenv('DATA_DIR') or ('/app/data' if os.path.exists('/app/data') else 'data')
+DATA_DIR = str(load_paths_config().data_dir)
 STATE_FILE = Path(DATA_DIR) / 'xkcd_state.json'
 
 
@@ -69,16 +68,15 @@ async def fetch_latest_xkcd() -> dict | None:
     return None
 
 
-async def post_xkcd_update():
+async def post_xkcd_update(settings: Config = None):
     """Check for new XKCD and post if found."""
-    token = get_secret('DISCORD', 'BOT_TOKEN')
-    # Prefer persisted channel in state if present (set via runtime command)
+    if settings is None:
+        settings = load_config()
+    token = settings.discord.bot_token.reveal()
+    # Prefer persisted channel in state if present (set via runtime command);
+    # the environment value arrives already validated as a Discord id.
     state = load_state()
-    channel_id = state.get('channel_id') or get_secret('XKCD', 'POST_CHANNEL_ID')
-    
-    if not token:
-        logger.error("DISCORD_BOT_TOKEN not set")
-        return False
+    channel_id = state.get('channel_id') or settings.posting.xkcd_channel_id
     
     if not channel_id:
         logger.error("XKCD_POST_CHANNEL_ID not set")
@@ -95,7 +93,7 @@ async def post_xkcd_update():
         logger.info("XKCD posting is disabled")
         return True
     
-    # Sanitize channel id (allow mentions or quoted strings)
+    # Sanitize a state-file channel id (allow mentions or quoted strings)
     try:
         if isinstance(channel_id, str):
             sanitized = ''.join(ch for ch in channel_id if ch.isdigit())
@@ -183,7 +181,12 @@ async def post_xkcd_update():
 if __name__ == '__main__':
     logger.info("XKCD runner starting...")
     try:
-        asyncio.run(post_xkcd_update())
+        settings = load_config()
+    except ConfigError as e:
+        logger.error("Refusing to run:\n%s", e)
+        sys.exit(1)
+    try:
+        asyncio.run(post_xkcd_update(settings))
         logger.info("XKCD runner completed")
         sys.exit(0)
     except Exception as e:

--- a/scripts/check-config.py
+++ b/scripts/check-config.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Configuration pre-flight.
+
+Loads the environment exactly the way bot.py does (.env, then the secrets
+manager on top) and validates it with utils.config. Prints OK plus a
+values-free summary, or the full list of missing and malformed variables.
+Exit code 0 when the bot would start, 1 when it would refuse.
+
+Meant for a container init step or a deploy hook:
+
+    python scripts/check-config.py
+    docker compose run --rm penguin-overlord python scripts/check-config.py
+
+Never prints a value: secrets are redacted by type, and the summary is
+counts and on/off flags only.
+"""
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / 'penguin-overlord'))
+
+from dotenv import load_dotenv  # noqa: E402
+
+from utils.config import ConfigError, describe_config, load_config  # noqa: E402
+
+
+def main() -> int:
+    load_dotenv()
+    try:
+        config = load_config()
+    except ConfigError as e:
+        print(f'FAIL: {e}', file=sys.stderr)
+        return 1
+    print(f'OK: {describe_config(config)}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,418 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Tests for utils/config.py.
+
+Every test passes an explicit `env` mapping, so nothing here reads the real
+environment or a .env file. The properties worth pinning: a good env loads
+into typed values with the documented defaults, a bad env produces ONE
+error that names every problem, and a secret never leaks into an error
+message or a repr.
+"""
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from utils.config import (
+    NEWS_CATEGORIES,
+    Config,
+    ConfigError,
+    Secret,
+    describe_config,
+    load_config,
+    load_logging_config,
+    load_metrics_config,
+    load_paths_config,
+)
+
+TOKEN = 'MTIzNDU2Nzg5.fake-token-value.not-real-but-secret'
+SNOWFLAKE = '123456789012345678'
+OTHER_SNOWFLAKE = '234567890123456789'
+
+MINIMAL = {'DISCORD_BOT_TOKEN': TOKEN}
+
+
+def _load(**overrides) -> Config:
+    env = dict(MINIMAL)
+    env.update(overrides)
+    return load_config(env)
+
+
+def _problems(**overrides) -> str:
+    env = dict(MINIMAL)
+    env.update(overrides)
+    with pytest.raises(ConfigError) as excinfo:
+        load_config(env)
+    return str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Happy path and defaults
+# ---------------------------------------------------------------------------
+
+def test_minimal_env_loads_with_features_off():
+    config = _load()
+
+    assert config.discord.bot_token.reveal() == TOKEN
+    assert config.discord.owner_id is None
+    assert config.logging.level == logging.INFO
+    assert config.logging.file is None
+    assert config.metrics.enabled is False
+    assert config.metrics.port == 9200
+    assert config.ai.enabled is False
+    assert config.moderation.enabled is False
+    assert config.moderation.dry_run is True
+    assert config.greeter.enabled is False
+    assert config.helper.enabled is False
+    assert config.role_picker.enabled is False
+    assert config.profile_screen.enabled is False
+    # The skid detector is the one feature that ships on by default.
+    assert config.skid_detector.enabled is True
+    assert all(config.news.channel_id(c) is None for c in NEWS_CATEGORIES)
+    assert config.news.auto_post is True
+
+
+def test_full_env_round_trips_every_parser():
+    config = _load(
+        DISCORD_OWNER_ID=SNOWFLAKE,
+        LOG_LEVEL='debug',
+        LOG_FILE='/var/log/penguin/bot.log',
+        LOG_MAX_BYTES='2048',
+        LOG_BACKUPS='3',
+        DATA_DIR='/srv/penguin',
+        METRICS_ENABLED='yes',
+        METRICS_PORT='9300',
+        NEWS_TECH_CHANNEL_ID=SNOWFLAKE,
+        NEWS_KEV_CHANNEL_ID=OTHER_SNOWFLAKE,
+        NEWS_AUTO_POST='false',
+        XKCD_POST_CHANNEL_ID=SNOWFLAKE,
+        XKCD_POLL_INTERVAL_MINUTES='15',
+        AI_ENABLED='1',
+        OLLAMA_HOST='ollama.lan',
+        OLLAMA_PORT='11500',
+        AI_DEFAULT_TEMPERATURE='0.4',
+        AI_ROASTING_ENABLED='true',
+        AI_ROASTING_MODEL='gemma4:12b',
+        MOD_ENABLED='true',
+        MOD_CHANNELS=f'{SNOWFLAKE}, {OTHER_SNOWFLAKE}',
+        MOD_IGNORED_CATEGORIES='Spam, violence',
+        MOD_MIN_CONFIDENCE='0.6',
+        MOD_TIMEOUT_MINUTES='15',
+        MOD_PROFILE='cybersecurity,hobbyist',
+        WELCOME_ENABLED='on',
+        WELCOME_VERIFY_DAILY_AT='9:30',
+        WELCOME_TIMEZONE='America/New_York',
+        HELPER_TIERS='new,member',
+        PROFILE_SCREEN_PROTECTED_NAMES='chiefgyk3d, penguin overlord',
+        SKID_FIRE_CHANCE='0.5',
+    )
+
+    assert config.discord.owner_id == int(SNOWFLAKE)
+    assert config.logging.level == logging.DEBUG
+    assert config.logging.file == '/var/log/penguin/bot.log'
+    assert config.logging.max_bytes == 2048
+    assert config.logging.backups == 3
+    assert config.paths.data_dir == Path('/srv/penguin')
+    assert config.paths.database_path == Path('/srv/penguin/penguin_overlord.db')
+    assert config.metrics.enabled is True
+    assert config.metrics.port == 9300
+    assert config.news.tech == int(SNOWFLAKE)
+    assert config.news.channel_id('kev') == int(OTHER_SNOWFLAKE)
+    assert config.news.auto_post is False
+    assert config.posting.xkcd_channel_id == int(SNOWFLAKE)
+    assert config.posting.xkcd_poll_interval_minutes == 15
+    assert config.ai.enabled is True
+    assert config.ai.ollama_host == 'http://ollama.lan:11500'
+    assert config.ai.default_temperature == 0.4
+    assert config.ai.features['roasting'].enabled is True
+    assert config.ai.features['roasting'].model == 'gemma4:12b'
+    assert config.ai.features['news'].enabled is False
+    assert config.moderation.enabled is True
+    assert config.moderation.channels == frozenset({int(SNOWFLAKE), int(OTHER_SNOWFLAKE)})
+    assert config.moderation.ignored_categories == frozenset({'spam', 'violence'})
+    assert config.moderation.min_confidence == 0.6
+    assert config.moderation.timeout_minutes == 15
+    assert config.moderation.profile == ('cybersecurity', 'hobbyist')
+    assert config.greeter.enabled is True
+    assert config.greeter.verify_daily_at == (9, 30)
+    assert config.greeter.timezone == 'America/New_York'
+    assert config.helper.tiers == frozenset({'new', 'member'})
+    assert config.profile_screen.protected_names == ('chiefgyk3d', 'penguin overlord')
+    assert config.skid_detector.fire_chance == 0.5
+
+
+def test_config_is_frozen():
+    config = _load()
+    with pytest.raises(AttributeError):
+        config.metrics = None  # type: ignore[misc]
+    with pytest.raises(AttributeError):
+        config.metrics.port = 1  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Individual parsers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('raw', ['true', 'True', ' TRUE ', '1', 'yes', 'on'])
+def test_bool_truthy_spellings(raw):
+    assert _load(METRICS_ENABLED=raw).metrics.enabled is True
+
+
+@pytest.mark.parametrize('raw', ['false', '0', 'no', 'off', ''])
+def test_bool_falsy_spellings(raw):
+    assert _load(METRICS_ENABLED=raw).metrics.enabled is False
+
+
+def test_bool_rejects_nonsense():
+    message = _problems(METRICS_ENABLED='maybe')
+    assert 'METRICS_ENABLED' in message
+    assert 'true/false' in message
+
+
+def test_int_rejects_non_numeric():
+    message = _problems(METRICS_PORT='nine thousand')
+    assert 'METRICS_PORT' in message
+    assert 'integer' in message
+
+
+def test_int_accepts_surrounding_whitespace():
+    assert _load(METRICS_PORT=' 9201 ').metrics.port == 9201
+
+
+def test_float_rejects_non_numeric():
+    message = _problems(MOD_MIN_CONFIDENCE='high')
+    assert 'MOD_MIN_CONFIDENCE' in message
+    assert 'number' in message
+
+
+def test_comma_list_strips_blanks_and_lowercases():
+    config = _load(MOD_RECLAIMED_TIERS=' Veteran,, trusted ,')
+    assert config.moderation.reclaimed_tiers == frozenset({'veteran', 'trusted'})
+
+
+def test_empty_string_means_unset():
+    # .env files routinely carry `VAR=` for every optional key; that must
+    # read as "not configured", never as a malformed value.
+    config = _load(NEWS_TECH_CHANNEL_ID='', MOD_ALERT_CHANNEL_ID='', LOG_MAX_BYTES='')
+    assert config.news.tech is None
+    assert config.moderation.alert_channel_id is None
+    assert config.logging.max_bytes == 10 * 1024 * 1024
+
+
+def test_example_placeholder_means_unset():
+    # bot.py has always ignored the `your_..._here` values from .env.example
+    # for the owner id; the loader keeps that so a half-filled example file
+    # reports "not set" rather than "malformed".
+    config = _load(DISCORD_OWNER_ID='your_discord_user_id_here')
+    assert config.discord.owner_id is None
+
+
+def test_time_parses_hh_mm():
+    config = _load(WELCOME_JOIN_DAILY_AT='23:05')
+    assert config.greeter.join_daily_at == (23, 5)
+
+
+@pytest.mark.parametrize('raw', ['24:00', '9:60', 'noon', '9', '09:5'])
+def test_time_rejects_out_of_range_and_wrong_shape(raw):
+    message = _problems(WELCOME_JOIN_DAILY_AT=raw)
+    assert 'WELCOME_JOIN_DAILY_AT' in message
+    assert 'HH:MM' in message
+
+
+def test_timezone_must_be_iana():
+    message = _problems(WELCOME_TIMEZONE='Eastern')
+    assert 'WELCOME_TIMEZONE' in message
+    assert 'IANA' in message
+
+
+def test_log_level_must_be_a_known_name():
+    message = _problems(LOG_LEVEL='chatty')
+    assert 'LOG_LEVEL' in message
+    assert 'DEBUG' in message
+
+
+def test_discord_token_alias_is_accepted():
+    # The runners historically fell back to DISCORD_TOKEN.
+    config = load_config({'DISCORD_TOKEN': TOKEN})
+    assert config.discord.bot_token.reveal() == TOKEN
+
+
+def test_ollama_host_with_scheme_is_kept_verbatim():
+    config = _load(AI_DEFAULT_OLLAMA_HOST='https://ollama.example:8443')
+    assert config.ai.ollama_host == 'https://ollama.example:8443'
+
+
+def test_ollama_host_defaults_to_localhost():
+    assert _load().ai.ollama_host == 'http://localhost:11434'
+
+
+# ---------------------------------------------------------------------------
+# Snowflakes
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize('raw', ['12345678901234567', '123456789012345678', '12345678901234567890'])
+def test_snowflake_accepts_17_to_20_digits(raw):
+    assert _load(NEWS_CVE_CHANNEL_ID=raw).news.cve == int(raw)
+
+
+def test_snowflake_accepts_channel_mention_wrapper():
+    # The xkcd/comic runners tolerated `<#id>` and quoted ids; keep that.
+    assert _load(XKCD_POST_CHANNEL_ID=f'<#{SNOWFLAKE}>').posting.xkcd_channel_id == int(SNOWFLAKE)
+    assert _load(COMIC_POST_CHANNEL_ID=f'"{SNOWFLAKE}"').posting.comic_channel_id == int(SNOWFLAKE)
+
+
+@pytest.mark.parametrize('raw', ['1234', '1234567890123456', '123456789012345678901', 'general', '12345678901234567x'])
+def test_snowflake_rejects_wrong_shapes(raw):
+    message = _problems(NEWS_GAMING_CHANNEL_ID=raw)
+    assert 'NEWS_GAMING_CHANNEL_ID' in message
+    assert '17 to 20 digits' in message
+
+
+def test_snowflake_list_rejects_one_bad_entry():
+    message = _problems(MOD_TRUSTED_ROLES=f'{SNOWFLAKE},nope')
+    assert 'MOD_TRUSTED_ROLES' in message
+    assert 'nope' in message
+
+
+def test_owner_id_is_a_snowflake():
+    message = _problems(DISCORD_OWNER_ID='42')
+    assert 'DISCORD_OWNER_ID' in message
+
+
+# ---------------------------------------------------------------------------
+# Aggregated errors
+# ---------------------------------------------------------------------------
+
+def test_missing_token_is_the_one_required_variable():
+    with pytest.raises(ConfigError) as excinfo:
+        load_config({})
+    message = str(excinfo.value)
+    assert 'DISCORD_BOT_TOKEN' in message
+    assert 'required' in message
+    assert excinfo.value.problems == [excinfo.value.problems[0]]  # exactly one
+
+
+def test_every_problem_is_reported_in_one_error():
+    with pytest.raises(ConfigError) as excinfo:
+        load_config({
+            'DISCORD_OWNER_ID': 'me',
+            'METRICS_PORT': 'x',
+            'NEWS_TECH_CHANNEL_ID': '12',
+            'WELCOME_JOIN_DAILY_AT': '25:00',
+            'LOG_BACKUPS': 'many',
+        })
+    error = excinfo.value
+    names = [p.split(':', 1)[0] for p in error.problems]
+    # The missing token plus the five malformed values, each exactly once.
+    assert sorted(names) == sorted([
+        'DISCORD_BOT_TOKEN', 'DISCORD_OWNER_ID', 'METRICS_PORT',
+        'NEWS_TECH_CHANNEL_ID', 'WELCOME_JOIN_DAILY_AT', 'LOG_BACKUPS',
+    ])
+    message = str(error)
+    assert message.startswith('6 configuration problem')
+    for name in names:
+        assert message.count(name) == 1
+
+
+def test_problem_lines_include_the_offending_value_for_non_secrets():
+    message = _problems(NEWS_TECH_CHANNEL_ID='general')
+    assert "'general'" in message
+
+
+# ---------------------------------------------------------------------------
+# Secrets never leak
+# ---------------------------------------------------------------------------
+
+def test_secret_repr_and_str_are_redacted():
+    secret = Secret(TOKEN)
+    assert TOKEN not in repr(secret)
+    assert TOKEN not in str(secret)
+    assert TOKEN not in f'{secret}'
+    assert secret.reveal() == TOKEN
+
+
+def test_secret_does_not_appear_in_config_repr():
+    config = _load(GEMINI_API_KEY='AIza-fake-gemini-key')
+    text = repr(config)
+    assert TOKEN not in text
+    assert 'AIza-fake-gemini-key' not in text
+    assert config.ai.gemini_api_key.reveal() == 'AIza-fake-gemini-key'
+
+
+def test_secret_does_not_appear_in_error_text():
+    # A token that is set but every other secret-shaped value malformed:
+    # the error must name the variables and never echo any secret.
+    with pytest.raises(ConfigError) as excinfo:
+        load_config({'DISCORD_BOT_TOKEN': TOKEN, 'METRICS_PORT': TOKEN + '-as-port'})
+    assert TOKEN not in str(excinfo.value)
+    assert TOKEN not in repr(excinfo.value)
+
+
+def test_secret_does_not_appear_in_describe():
+    text = describe_config(_load(GEMINI_API_KEY='AIza-fake-gemini-key', NEWS_TECH_CHANNEL_ID=SNOWFLAKE))
+    assert TOKEN not in text
+    assert 'AIza-fake-gemini-key' not in text
+    assert SNOWFLAKE not in text  # ids are not secret, but the summary is counts only
+    assert 'news' in text
+
+
+# ---------------------------------------------------------------------------
+# Secrets manager integration
+# ---------------------------------------------------------------------------
+
+def test_secret_lookup_wins_over_env_and_is_asked_per_platform():
+    asked = []
+
+    def fake_secrets(platform, key):
+        asked.append((platform, key))
+        if (platform, key) == ('DISCORD', 'BOT_TOKEN'):
+            return 'from-doppler'
+        if (platform, key) == ('NEWS', 'TECH_CHANNEL_ID'):
+            return SNOWFLAKE
+        return None
+
+    config = load_config({'DISCORD_BOT_TOKEN': 'from-env', 'NEWS_TECH_CHANNEL_ID': ''}, secrets=fake_secrets)
+    assert config.discord.bot_token.reveal() == 'from-doppler'
+    assert config.news.tech == int(SNOWFLAKE)
+    assert ('DISCORD', 'BOT_TOKEN') in asked
+    assert ('MOD', 'ALERT_CHANNEL_ID') in asked
+    # Plain settings (logging, metrics, paths) never hit the secrets manager.
+    assert not any(platform in ('LOG', 'METRICS', 'DATA') for platform, _ in asked)
+
+
+def test_env_mapping_never_consults_secrets_by_default(monkeypatch):
+    monkeypatch.setenv('DISCORD_BOT_TOKEN', 'real-env-must-not-be-read')
+    with pytest.raises(ConfigError):
+        load_config({})
+
+
+# ---------------------------------------------------------------------------
+# Lenient section loaders for the pre-config bootstrap
+# ---------------------------------------------------------------------------
+
+def test_logging_section_substitutes_defaults_instead_of_raising():
+    settings = load_logging_config({'LOG_LEVEL': 'chatty', 'LOG_MAX_BYTES': 'lots', 'LOG_FILE': '/tmp/x.log'})
+    assert settings.level == logging.INFO
+    assert settings.max_bytes == 10 * 1024 * 1024
+    assert settings.file == '/tmp/x.log'
+
+
+def test_metrics_section_substitutes_defaults_instead_of_raising():
+    settings = load_metrics_config({'METRICS_ENABLED': 'true', 'METRICS_PORT': 'nope'})
+    assert settings.enabled is True
+    assert settings.port == 9200
+
+
+def test_paths_section_prefers_data_dir_env(tmp_path):
+    settings = load_paths_config({'DATA_DIR': str(tmp_path)})
+    assert settings.data_dir == tmp_path
+    assert settings.xkcd_state_path == tmp_path / 'xkcd_state.json'
+    assert settings.comic_state_path == tmp_path / 'comic_state.json'
+
+
+def test_state_path_overrides_are_honoured(tmp_path):
+    settings = load_paths_config({'DATA_DIR': str(tmp_path), 'XKCD_STATE_PATH': '/elsewhere/x.json'})
+    assert settings.xkcd_state_path == Path('/elsewhere/x.json')


### PR DESCRIPTION
## Summary

One typed configuration module, `penguin-overlord/utils/config.py`, that reads the whole environment once at startup and refuses to start with a single `ConfigError` listing every missing or malformed variable. Frozen dataclasses, stdlib only.

Before: each feature ran its own `os.getenv`, so a typo in one channel id showed up hours later as a silent no-post, and a missing token gave a different error in each of the six entry points. Now:

```
❌ Refusing to start:
3 configuration problems:
  - DISCORD_BOT_TOKEN: required, not set
  - NEWS_TECH_CHANNEL_ID: expected a Discord id (17 to 20 digits), got 'general'
  - METRICS_PORT: expected an integer between 1 and 65535, got 'x'
```

Behaviour for a correct `.env` is unchanged. The only visible change is the startup error (and exit code 1) for a broken one.

## What changed

- **`utils/config.py`** (new): `Config` with sections `discord`, `logging`, `paths`, `news`, `posting`, `metrics`, `ai`, `moderation`, `greeter`, `helper`, `role_picker`, `profile_screen`, `skid_detector`, `banter`. `load_config(env=None, *, secrets=None)` parses bools, bounded ints, floats, snowflakes (17 to 20 digits, `<#id>`/`<@id>`/`<@&id>` wrappers stripped), comma lists, `HH:MM` times, IANA timezones and log levels, collecting every problem before raising. `env` is a parameter so tests never touch the real environment. Secret-shaped values go through `utils.secrets.get_secret(platform, key)` first, exactly as the cogs do, so Doppler/AWS/Vault keep overriding `.env`. `Secret` wraps the token and Gemini key and redacts itself in `repr`/`str`; error lines echo the value only for non-secret variables, truncated to 32 chars. A value starting with `your_` is treated as unset (bot.py already did this for the owner id). `DISCORD_TOKEN` stays accepted as an alias for `DISCORD_BOT_TOKEN` because the runners read it.
- **Lenient section loaders** `load_logging_config`, `load_metrics_config`, `load_paths_config` for the three import-time reads that must happen before `load_config()` can run (logging has to exist to report the error). They substitute defaults and never raise; `load_config()` then reports the same bad value.
- **Migrated:** `bot.py`, `news_runner.py`, `kev_runner.py`, `solar_runner.py`, `xkcd_runner.py`, `comics_runner.py`, `utils/logging_setup.py`, `utils/metrics.py`. Each entry point loads the config first and exits 1 on `ConfigError`. `PenguinOverlord(config)` stores it as `self.config` for cogs to pick up later.
- **`scripts/check-config.py`** (new): same load as `bot.py` (`.env` then secrets manager), prints `OK: <counts-only summary>` or `FAIL: <error list>`, exit 0/1. Never prints a value.
- **`docs/reference/CONFIGURATION.md`** (new), linked from `docs/README.md` and `README.md`: sections, value shapes, error format, check-config usage, how to add a variable.
- **`tests/unit/test_config.py`** (new, 56 tests, written first): every parser, aggregation, secret redaction, secrets-manager priority via a fake callable, hermetic `env`, lenient loaders.

No variable was renamed, so `.env.example` is untouched. `cogs/` and `ai/` are untouched.

## Inventory

Every `os.getenv` / `os.environ` / `get_secret` read in the tree. "Where read" lists the pre-PR readers; "Section" is where it now lives. 157 variable names are modelled (35 of them the per-feature `AI_<FEATURE>_*` overrides). **Exactly one is required: `DISCORD_BOT_TOKEN`.**

<details>
<summary>Full table (click to expand)</summary>

| Variable | Where read (before) | Type | Default | Required | Section |
|---|---|---|---|---|---|
| `DISCORD_BOT_TOKEN` | bot.py (via get_secret), all 5 runners | secret | none | **yes** | discord |
| `DISCORD_TOKEN` | runners | secret (alias) | none | no | discord |
| `DISCORD_OWNER_ID` | bot.py | snowflake | unset | no | discord |
| `LOG_LEVEL` | utils/logging_setup.py | level | `INFO` | no | logging |
| `LOG_FILE` | utils/logging_setup.py | str | unset | no | logging |
| `LOG_MAX_BYTES` | utils/logging_setup.py | int >= 1 | `10485760` | no | logging |
| `LOG_BACKUPS` | utils/logging_setup.py | int >= 0 | `5` | no | logging |
| `DATA_DIR` | utils/state.py, xkcd/comics runners, cogs/comics, cogs/xkcd_poster | path | `/app/data` if present else `data` | no | paths |
| `BOT_DATABASE_PATH` | utils/database.py | path | `<DATA_DIR>/penguin_overlord.db` | no | paths |
| `XKCD_STATE_PATH` | cogs/xkcd_poster.py | path | `<DATA_DIR>/xkcd_state.json` | no | paths |
| `COMIC_STATE_PATH` | cogs/comics.py | path | `<DATA_DIR>/comic_state.json` | no | paths |
| `NEWS_CYBERSECURITY_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_TECH_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_GAMING_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_APPLE_GOOGLE_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_CVE_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_KEV_CHANNEL_ID` | kev_runner.py, news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_US_LEGISLATION_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_EU_LEGISLATION_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_UK_LEGISLATION_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_GENERAL_NEWS_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_VENDOR_ALERTS_CHANNEL_ID` | news_runner.py, cogs/news_manager.py | snowflake | unset | no | news |
| `NEWS_AUTO_POST` | utils/news_dedupe.py | bool | `true` | no | news |
| `XKCD_POST_CHANNEL_ID` | xkcd_runner.py, cogs/xkcd_poster.py | snowflake | unset | no | posting |
| `XKCD_POLL_INTERVAL_MINUTES` | cogs/xkcd_poster.py | int >= 1 | `30` | no | posting |
| `COMIC_POST_CHANNEL_ID` | comics_runner.py, cogs/comics.py | snowflake | unset | no | posting |
| `SOLAR_POST_CHANNEL_ID` | solar_runner.py, cogs/radiohead.py | snowflake | unset | no | posting |
| `METRICS_ENABLED` | utils/metrics.py, scripts/healthcheck.py | bool | `false` | no | metrics |
| `METRICS_PORT` | utils/metrics.py, scripts/healthcheck.py | int 1..65535 | `9200` | no | metrics |
| `AI_ENABLED` | ai/config.py | bool | `false` | no | ai |
| `AI_DEFAULT_OLLAMA_HOST` | ai/config.py | str | unset | no | ai |
| `OLLAMA_HOST` | ai/config.py | str | `localhost` | no | ai |
| `OLLAMA_PORT` | ai/config.py | str | `11434` | no | ai |
| `AI_DEFAULT_MODEL` | ai/config.py | str | unset | no | ai |
| `OLLAMA_MODEL` | ai/config.py | str | `llama3.2` | no | ai |
| `AI_DEFAULT_TEMPERATURE` | ai/config.py | float | `0.7` | no | ai |
| `AI_DEFAULT_MAX_TOKENS` | ai/config.py | int | `256` | no | ai |
| `AI_DEFAULT_TIMEOUT` | ai/config.py | float | `30.0` | no | ai |
| `GEMINI_API_KEY` | ai/config.py | secret | unset | no | ai |
| `AI_GEMINI_FALLBACK` | ai/config.py | bool | `false` | no | ai |
| `AI_GEMINI_MODEL` | ai/config.py | str | `gemini-2.0-flash` | no | ai |
| `AI_MAX_CONCURRENT_REQUESTS` | ai/config.py | int >= 1 | `2` | no | ai |
| `AI_MAX_PENDING_REQUESTS` | ai/config.py | int >= 0 | `20` | no | ai |
| `AI_MIN_DELAY_BETWEEN_REQUESTS` | ai/config.py | float | `0.5` | no | ai |
| `AI_MAX_RETRIES` | ai/config.py | int >= 0 | `2` | no | ai |
| `AI_RETRY_DELAY_BASE` | ai/config.py | float | `2.0` | no | ai |
| `AI_RECONNECT_INTERVAL` | ai/config.py | float | `60.0` | no | ai |
| `AI_<F>_ENABLED` (F = ROASTING, MODERATION, NEWS, CVE, LEGISLATION) | ai/config.py | bool | `false` | no | ai.features |
| `AI_<F>_MODEL` | ai/config.py | str | unset (global default) | no | ai.features |
| `AI_<F>_OLLAMA_HOST` | ai/config.py | str | unset (global default) | no | ai.features |
| `AI_<F>_TEMPERATURE` | ai/config.py | float | unset (global default) | no | ai.features |
| `AI_<F>_MAX_TOKENS` | ai/config.py | int | unset (global default) | no | ai.features |
| `AI_<F>_TIMEOUT` | ai/config.py | float | unset (global default) | no | ai.features |
| `AI_<F>_GEMINI_FALLBACK` | ai/config.py | bool | unset (global default) | no | ai.features |
| `AI_MODERATION_SECOND_MODEL` | ai/features/moderation.py | str | unset | no | moderation |
| `AI_MODERATION_SECOND_CATEGORIES` | ai/features/moderation.py | word list | `hate_speech,harassment` | no | moderation |
| `AI_MODERATION_SECOND_MIN_CONFIDENCE` | ai/features/moderation.py | float | `0.85` | no | moderation |
| `MOD_ENABLED` | cogs/ai_moderation.py | bool | `false` | no | moderation |
| `MOD_DRY_RUN` | cogs/ai_moderation.py | bool | `true` | no | moderation |
| `MOD_AUTO_DELETE` | cogs/ai_moderation.py | bool | `false` | no | moderation |
| `MOD_AUTO_TIMEOUT` | cogs/ai_moderation.py | bool | `false` | no | moderation |
| `MOD_MIN_CONFIDENCE` | cogs/ai_moderation.py | float | `0.75` | no | moderation |
| `MOD_ALERT_MIN_CONFIDENCE` | cogs/ai_moderation.py | float | `0.0` | no | moderation |
| `MOD_IGNORED_CATEGORIES` | cogs/ai_moderation.py | word list | empty | no | moderation |
| `MOD_TIMEOUT_MINUTES` | cogs/ai_moderation.py | int | `10` | no | moderation |
| `MOD_MIN_MESSAGE_LENGTH` | cogs/ai_moderation.py | int | `6` | no | moderation |
| `MOD_USER_COOLDOWN_SECONDS` | cogs/ai_moderation.py | float | `20` | no | moderation |
| `MOD_RETENTION_DAYS` | cogs/ai_moderation.py | int | `90` | no | moderation |
| `MOD_ALERT_CHANNEL_ID` | cogs/ai_moderation.py, cogs/profile_screen.py | snowflake | unset | no | moderation |
| `MOD_PING_ROLE_ID` | cogs/ai_moderation.py | snowflake | unset | no | moderation |
| `MOD_CHANNELS` | cogs/ai_moderation.py | snowflake list | empty (all) | no | moderation |
| `MOD_IGNORED_ROLES` | cogs/ai_moderation.py | snowflake list | empty | no | moderation |
| `MOD_TRUSTED_ROLES` | cogs/ai_moderation.py, cogs/newcomer_helper.py | snowflake list | empty | no | moderation |
| `MOD_CREATOR_ROLES` | cogs/ai_moderation.py, cogs/newcomer_helper.py | snowflake list | empty | no | moderation |
| `MOD_MEMBER_DAYS` | cogs/ai_moderation.py, cogs/newcomer_helper.py | int | `30` | no | moderation |
| `MOD_VETERAN_DAYS` | cogs/ai_moderation.py, cogs/newcomer_helper.py | int | `365` | no | moderation |
| `MOD_RECLAIMED_TIERS` | cogs/ai_moderation.py | word list | `veteran,trusted,creator` | no | moderation |
| `MOD_PROFILE` | cogs/ai_moderation.py, ai/features/moderation.py | word list | `general` | no | moderation |
| `MOD_REVIEW_VOTES` | cogs/ai_moderation.py | int >= 1 | `1` | no | moderation |
| `MOD_LENIENCY_MAX_CONFIDENCE` | cogs/ai_moderation.py | float | `0.95` | no | moderation |
| `MOD_RULES_CHANNEL_ID` | cogs/rules_sync.py | snowflake | unset | no | moderation |
| `MOD_RULES_SYNC_HOURS` | cogs/rules_sync.py | float | `24` | no | moderation |
| `WELCOME_ENABLED` | cogs/welcome_greeter.py | bool | `false` | no | greeter |
| `WELCOME_MAX_MENTIONS` | cogs/welcome_greeter.py | int >= 1 | `12` | no | greeter |
| `WELCOME_CHANNEL_ID` | cogs/welcome_greeter.py | snowflake | unset | no | greeter |
| `WELCOME_VERIFY_CHANNEL_ID` | cogs/welcome_greeter.py | snowflake | unset | no | greeter |
| `WELCOME_RULES_CHANNEL_ID` | cogs/welcome_greeter.py | snowflake | unset | no | greeter |
| `WELCOME_ROLES_CHANNEL_ID` | cogs/welcome_greeter.py | snowflake | unset | no | greeter |
| `WELCOME_RESOURCE_CHANNEL_ID` | cogs/welcome_greeter.py | snowflake | unset | no | greeter |
| `WELCOME_WAGON_CHANNEL_ID` | cogs/welcome_greeter.py | snowflake | unset | no | greeter |
| `WELCOME_GENERAL_CHANNEL_ID` | cogs/welcome_greeter.py | snowflake | unset | no | greeter |
| `WELCOME_ROLE_ID` | cogs/welcome_greeter.py | snowflake | unset | no | greeter |
| `WELCOME_TIMEZONE` | cogs/welcome_greeter.py | timezone | `UTC` | no | greeter |
| `WELCOME_RETRACT_WINDOW_SECONDS` | cogs/welcome_greeter.py | float | `86400` | no | greeter |
| `WELCOME_JOIN_ENABLED` | cogs/welcome_greeter.py | bool | `true` | no | greeter |
| `WELCOME_JOIN_CHANNEL_ID` | cogs/welcome_greeter.py | snowflake | unset | no | greeter |
| `WELCOME_JOIN_MESSAGE` | cogs/welcome_greeter.py | str | unset | no | greeter |
| `WELCOME_JOIN_IMAGE` | cogs/welcome_greeter.py | str | unset | no | greeter |
| `WELCOME_JOIN_COOLDOWN_SECONDS` | cogs/welcome_greeter.py | float | `900` | no | greeter |
| `WELCOME_JOIN_REMIND_AFTER_SECONDS` | cogs/welcome_greeter.py | float | `300` | no | greeter |
| `WELCOME_JOIN_DAILY_AT` | cogs/welcome_greeter.py | HH:MM | unset | no | greeter |
| `WELCOME_VERIFY_ENABLED` | cogs/welcome_greeter.py | bool | `true` | no | greeter |
| `WELCOME_VERIFY_MESSAGE` | cogs/welcome_greeter.py | str | unset | no | greeter |
| `WELCOME_VERIFY_IMAGE` | cogs/welcome_greeter.py | str | unset | no | greeter |
| `WELCOME_VERIFY_COOLDOWN_SECONDS` | cogs/welcome_greeter.py | float | `10800` | no | greeter |
| `WELCOME_MAX_TENURE_DAYS` | cogs/welcome_greeter.py | float | `30` | no | greeter |
| `WELCOME_VERIFY_DAILY_AT` | cogs/welcome_greeter.py | HH:MM | unset | no | greeter |
| `HELPER_ENABLED` | cogs/newcomer_helper.py | bool | `false` | no | helper |
| `HELPER_CHANNELS` | cogs/newcomer_helper.py | snowflake list | empty | no | helper |
| `HELPER_TIERS` | cogs/newcomer_helper.py | word list | `new` | no | helper |
| `HELPER_COOLDOWN_SECONDS` | cogs/newcomer_helper.py | float | `60` | no | helper |
| `HELPER_USER_COOLDOWN_SECONDS` | cogs/newcomer_helper.py | float | `1800` | no | helper |
| `HELPER_MIN_LENGTH` | cogs/newcomer_helper.py | int | `12` | no | helper |
| `HELPER_USE_LLM` | cogs/newcomer_helper.py | bool | `true` | no | helper |
| `HELPER_RESOURCE_CHANNEL_ID` | cogs/newcomer_helper.py | snowflake | unset | no | helper |
| `HELPER_RULES_CHANNEL_ID` | cogs/newcomer_helper.py | snowflake | unset | no | helper |
| `HELPER_MESSAGE` | cogs/newcomer_helper.py | str | unset | no | helper |
| `ROLE_PICKER_ENABLED` | cogs/role_picker.py | bool | `false` | no | role_picker |
| `PROFILE_SCREEN_ENABLED` | cogs/profile_screen.py | bool | `false` | no | profile_screen |
| `PROFILE_SCREEN_LLM` | cogs/profile_screen.py | bool | `true` | no | profile_screen |
| `PROFILE_SCREEN_HOLD_GREETING` | cogs/profile_screen.py | bool | `true` | no | profile_screen |
| `PROFILE_SCREEN_PROTECTED_NAMES` | cogs/profile_screen.py | list (case kept) | empty | no | profile_screen |
| `SKID_DETECTOR_ENABLED` | cogs/skid_detector.py | bool | `true` | no | skid_detector |
| `SKID_FIRE_CHANCE` | cogs/skid_detector.py | float | `0.30` | no | skid_detector |
| `SKID_COOLDOWN_SECONDS` | cogs/skid_detector.py | float | `180` | no | skid_detector |
| `SKID_DETECTOR_LLM` | cogs/skid_detector.py | bool | `false` | no | skid_detector |
| `ARCH_BANTER_LLM` | cogs/arch_banter.py | bool | `false` | no | banter |

Deliberately **not** in `Config` (the config loader depends on them): the secrets bootstrap read by `utils/secrets.py` itself: `SECRETS_MANAGER`, `DOPPLER_TOKEN`, `DOPPLER_PROJECT`, `DOPPLER_CONFIG`, `DOPPLER_CACHE_TTL`, `SECRETS_VAULT_URL`, `SECRETS_VAULT_TOKEN`, `AWS_SECRET_NAME`, `VAULT_SECRET_PATH`.

</details>

## Behaviour notes (things that are now stricter, on purpose)

- Exit code 1 on a bad config, from every entry point, instead of a stack trace or a silent no-op.
- A non-numeric `DISCORD_OWNER_ID` or channel id is now fatal at startup. Before, the owner id was silently dropped and a bad channel id was logged and skipped at post time.
- `news_runner.py` now requires the token up front even when the category's channel is unset. Before, it only failed when it tried to log in.
- `bot.py` calls `load_dotenv()` before `configure_logging()`, so `LOG_LEVEL` in `.env` is honoured. Before, it only took effect when exported in the process environment.
- Runner leniency is preserved: `<#id>` wrappers still parse, `xkcd_runner`/`comics_runner` still prefer the channel id in their state file, and a runner with no channel configured still exits 0.

## What migrates next

`cogs/` and `ai/` still read the environment through their own `_env()` helpers; the bot now exposes `self.bot.config` so each can switch in its own PR. Rough sizes:

| File | Reads | Estimate |
|---|---|---|
| `ai/config.py` (+ `ai/features/moderation.py`) | ~60 vars via 3 helpers | medium: replace the `AIConfig` builder with a view over `config.ai`; needs care because cogs import `ai.config` at module level |
| `cogs/ai_moderation.py` | 26 `MOD_*` | medium, biggest cog |
| `cogs/welcome_greeter.py` | 25 `WELCOME_*` | medium |
| `cogs/newcomer_helper.py` | 10 `HELPER_*` + 4 `MOD_*` | small |
| `cogs/news_manager.py`, `cogs/xkcd_poster.py`, `cogs/comics.py`, `cogs/radiohead.py`, `cogs/rules_sync.py`, `cogs/profile_screen.py`, `cogs/role_picker.py`, `cogs/skid_detector.py`, `cogs/arch_banter.py` | 1 to 4 each | small, mechanical |
| `utils/state.py`, `utils/database.py`, `utils/news_dedupe.py`, `scripts/healthcheck.py` | 1 to 2 each | small; `state.py`/`database.py` are import-time and would use `load_paths_config()` |

Also worth a follow-up: `xkcd_runner`/`comics_runner` ignore `XKCD_STATE_PATH`/`COMIC_STATE_PATH` (only the cogs honour them). That discrepancy predates this PR and is left as-is; `config.paths` already carries both values, so fixing it is a two-line change once someone decides which behaviour is right. A `scripts/check-config.py` call in `docker-entrypoint` would turn a bad deploy into a failed healthcheck rather than a restart loop.

## How verified

- `tests/unit/test_config.py` written first and watched fail (`ModuleNotFoundError`), then the module built against it: **56 passed**.
- Full suite `python3 -m pytest tests/unit -q -p no:cacheprovider`: **551 passed, 1 skipped** (was 495 before this branch).
- CI command `pytest tests/ -m "not network" --cov=penguin-overlord --cov-fail-under=29`: 45.54% total; `utils/config.py` itself at 95%. Gate not lowered.
- `ruff check .`: clean.
- Hermetic smoke runs of `bot.py`, `kev_runner.py`, `xkcd_runner.py` and `check-config.py` with `dotenv` stubbed and `os.environ` cleared: nothing set reports 1 problem (the token); five bad values report 6 problems, each named once; a `your_...` placeholder token reports "required, not set"; a fake-token env prints the `OK:` line; a bad KEV channel id exits 1 before any network; xkcd with no channel exits 0 as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
