### PR TITLE
feat: region pickers hold several roles; each menu edits its own set

### DIFF
--- a/docs/features/ROLE_PICKER.md
+++ b/docs/features/ROLE_PICKER.md
@@ -1,7 +1,8 @@
 # Role picker (self-roles)
 
 MEE6-style self-assign roles, built on Discord components instead of
-reactions. Members pick from a dropdown; the bot swaps their role. This is
+reactions. Members tick regions in a dropdown; the bot sets their roles
+to match. This is
 the first piece of the MEE6 replacement track and the thing the events
 system tags when something is happening near you.
 
@@ -10,8 +11,16 @@ system tags when something is happening near you.
 - Posts a **panel**: an embed plus one select menu per group of up to 25
   options. Menus are persistent (fixed `custom_id`s, no stored state), so
   a restart never orphans one.
-- **Exclusive panels** hold one role per member: picking Michigan removes
-  Ohio. Clearing the menu removes the panel's role entirely.
+- **Non-exclusive panels** (all three shipped ones) are set editors: each
+  menu is multi-select, and submitting it is your complete choice for that
+  menu. Roles from that menu you did not tick are removed, roles from the
+  panel's other menus stay. In Ohio but driving to Michigan for GrrCON:
+  tick both. Discord does not pre-tick what you already hold, so the reply
+  reads back your full list ("You are now set for: **Indiana, Michigan,
+  Ohio**.").
+- **Exclusive panels** (`"exclusive": true`) hold one role per member:
+  picking one swaps out the other. Clearing the menu removes the panel's
+  role entirely. Use this for genuinely one-of choices.
 - **Provisions roles** from the panel definition: `/roles post` creates
   whatever is missing (not hoisted, not mentionable by members, so only
   the bot can ping them) and posts the panel.
@@ -63,15 +72,17 @@ Drop a JSON file in `assets/role_panels/`:
 ```
 
 Limits: 25 options per group, 5 groups per panel, role names 100 chars.
-`exclusive: false` lets a member hold several (a menu still sets one at a
-time; picking another adds it). Reposting a panel is safe: it only creates
-roles that are missing and posts a fresh copy; delete the old message by
-hand.
+`exclusive` defaults to true when omitted. Reposting a panel is safe: it
+only creates roles that are missing and posts a fresh copy; delete the old
+message by hand. Changing `exclusive` on a panel that is already posted
+needs a repost: the menu's tick limit is baked into the posted message.
 
 ## Notes
 
-- Menus answer ephemerally ("You are now **Michigan**. Swapped out
-  Ohio."), so the roles channel stays clean.
+- Menus answer ephemerally ("You are now set for: **Michigan, Ohio**."),
+  so the roles channel stays clean.
+- The events system treats every region role a member holds as a place
+  they want pings for; there is no separate "home" role.
 - The bot never removes a role it did not define in the panel.
 - If a role in a panel was deleted by hand, members get "not set up yet,
   ask a moderator to run /roles post" and the log records which role.

--- a/penguin-overlord/assets/role_panels/ca_provinces.json
+++ b/penguin-overlord/assets/role_panels/ca_provinces.json
@@ -1,8 +1,8 @@
 {
   "key": "ca_provinces",
   "title": "Canadian members: which province or territory?",
-  "description": "Pick your province or territory and you get a role for it, so event pings for your area reach you as a role and not as a personal mention.\n\nOne per person. Pick again to change, clear the menu to drop it.",
-  "exclusive": true,
+  "description": "Pick your province or territory and you get a role for it, so event pings for your area reach you as a role and not as a personal mention.\n\nTick every province or territory you want pings for, home included. Submitting the menu sets your whole list, and the bot reads it back to you.",
+  "exclusive": false,
   "groups": [
     {
       "placeholder": "Pick your province or territory",

--- a/penguin-overlord/assets/role_panels/country.json
+++ b/penguin-overlord/assets/role_panels/country.json
@@ -1,8 +1,8 @@
 {
   "key": "country",
   "title": "Where in the world are you?",
-  "description": "Pick your country and the bot gives you a role for it. This community is primarily US and Canada focused, and international members are very welcome; if your country is not listed, take International and we will add it when there are enough of you to matter.\n\nOne country per person. Pick again to change, clear the menu to drop it.",
-  "exclusive": true,
+  "description": "Pick your country and the bot gives you a role for it. This community is primarily US and Canada focused, and international members are very welcome; if your country is not listed, take International and we will add it when there are enough of you to matter.\n\nTick every country you want event pings for, home included: living in the US but flying out for a con in Canada or Israel means ticking those too. Submitting the menu sets your whole list, and the bot reads it back to you.",
+  "exclusive": false,
   "groups": [
     {
       "placeholder": "Pick your country",

--- a/penguin-overlord/assets/role_panels/us_states.json
+++ b/penguin-overlord/assets/role_panels/us_states.json
@@ -1,8 +1,8 @@
 {
   "key": "us_states",
   "title": "US members: which state?",
-  "description": "Pick your state (DC counts) and you get a role for it. This is how the events system will know to tag you when something is happening near you, and it is only ever tagged as a role, never as individual people.\n\nOne state per person. Pick again to change, clear the menu to drop it.",
-  "exclusive": true,
+  "description": "Pick your state (DC counts) and you get a role for it. This is how the events system will know to tag you when something is happening near you, and it is only ever tagged as a role, never as individual people.\n\nTick every state you would travel to for a con, home state included: in Ohio but driving to Michigan for GrrCON means ticking both. Each menu covers a range of states; submitting one sets your choice for that range only, and the bot reads back your full list.",
+  "exclusive": false,
   "groups": [
     {
       "placeholder": "Alabama to Kansas",

--- a/penguin-overlord/cogs/role_picker.py
+++ b/penguin-overlord/cogs/role_picker.py
@@ -16,13 +16,17 @@ A panel is a JSON file in assets/role_panels/ (see country.json):
     key          short id, used in custom_ids and slash-command choices
     title        embed title
     description  embed body, in the operator's voice
-    exclusive    true: picking one role in the panel removes the others
+    exclusive    true: one role per panel, picking one removes the others
+                 false: multi-select menus; a submission is the member's
+                 complete choice for that menu, other menus untouched
     groups[]     placeholder + options[] of {label, role, emoji?}
 
 The shipped panels are country (US and Canada first, then common
 countries, then International), us_states (50 + DC across three menus),
-and ca_provinces. Roles are named plainly ("Michigan", "Ontario") so the
-events system can resolve a region to a role by name.
+and ca_provinces. All three are non-exclusive: the roles route event
+pings, and someone in Ohio who drives to Michigan for GrrCON wants both.
+Roles are named plainly ("Michigan", "Ontario") so the events system can
+resolve a region to a role by name.
 
 Provisioning: `/roles post <panel> [#channel]` creates any missing roles
 (not hoisted, not mentionable by members: only the bot pings them) and
@@ -100,20 +104,34 @@ def missing_roles(panel: Panel, existing: set) -> list:
     return [name for name in panel.role_names() if name not in existing]
 
 
-def plan_change(panel: Panel, member_roles: set, chosen: list) -> tuple:
+def plan_change(panel: Panel, member_roles: set, chosen: list,
+                group: int | None = None) -> tuple:
     """Pure: which panel roles to add and remove for a member's choice.
+
+    Exclusive panel: one role for the whole panel, so a choice swaps out
+    whatever else the member held from it, and an empty choice clears it.
+
+    Non-exclusive panel: the submitted values are the member's complete
+    choice for that one menu (`group`). Roles from that menu they did not
+    tick are removed, roles from the panel's other menus are untouched, so
+    a member can hold Ohio, Michigan and Indiana across menus and edit any
+    one menu without losing the rest. Discord does not pre-tick current
+    roles when a menu opens, so the reply reads back the whole set.
+
     Unknown values are dropped (the API could never send one, but a stale
-    panel definition could), and an empty choice clears the panel."""
-    valid = set(panel.role_names())
-    wanted = [v for v in chosen if v in valid]
+    panel definition could)."""
+    if panel.exclusive:
+        scope = panel.role_names()
+    elif group is not None and 0 <= group < len(panel.groups):
+        scope = [o.role for o in panel.groups[group].options]
+    else:
+        scope = panel.role_names()
+    wanted = [v for v in chosen if v in scope]
     if panel.exclusive:
         wanted = wanted[:1]
     add = [name for name in wanted if name not in member_roles]
-    if panel.exclusive or not wanted:
-        remove = [name for name in panel.role_names()
-                  if name in member_roles and name not in wanted]
-    else:
-        remove = []
+    remove = [name for name in scope
+              if name in member_roles and name not in wanted]
     return add, remove
 
 
@@ -135,8 +153,11 @@ class PanelSelect(discord.ui.DynamicItem[discord.ui.Select],
         group = panel.groups[index]
         options = [discord.SelectOption(label=o.label, value=o.role, emoji=o.emoji)
                    for o in group.options]
+        # Exclusive panels are one-of, so one tick. Otherwise the menu is
+        # a set editor: tick everything you want from it, submit.
         super().__init__(discord.ui.Select(
-            placeholder=group.placeholder, min_values=0, max_values=1,
+            placeholder=group.placeholder, min_values=0,
+            max_values=1 if panel.exclusive else len(options),
             options=options, custom_id=f'rolepick:{panel.key}:{index}'))
         self.panel = panel
         self.index = index
@@ -171,7 +192,8 @@ class PanelSelect(discord.ui.DynamicItem[discord.ui.Select],
                 'Role picking is switched off right now.', ephemeral=True)
             return
         values = list(interaction.data.get('values') or [])
-        text = await cog.apply(self.panel, interaction.guild, interaction.user, values)
+        text = await cog.apply(self.panel, interaction.guild, interaction.user,
+                               values, group=self.index)
         await interaction.response.send_message(text, ephemeral=True)
 
 
@@ -210,11 +232,12 @@ class RolePicker(commands.Cog):
 
     # -------------------------------------------------------------- apply
 
-    async def apply(self, panel: Panel, guild, member, chosen: list) -> str:
+    async def apply(self, panel: Panel, guild, member, chosen: list,
+                    group: int | None = None) -> str:
         """Carry out a member's menu choice; returns the ephemeral reply."""
         by_name = {r.name: r for r in guild.roles}
         have = {r.name for r in member.roles}
-        add, remove = plan_change(panel, have, chosen)
+        add, remove = plan_change(panel, have, chosen, group)
 
         missing = [n for n in add if n not in by_name]
         if missing:
@@ -240,6 +263,16 @@ class RolePicker(commands.Cog):
 
         logger.info('Role panel %s: %s +%s -%s', panel.key, member.display_name,
                     add, remove)
+        if not panel.exclusive:
+            # The menu never shows what you already hold, so the reply does.
+            now = (have - set(remove)) | set(add)
+            held = [n for n in panel.role_names() if n in now]
+            if not add and not remove:
+                return 'No change.' + (
+                    f' You are set for: **{", ".join(held)}**.' if held else '')
+            if held:
+                return f'You are now set for: **{", ".join(held)}**.'
+            return f'Cleared: {", ".join(remove)} removed.'
         if add:
             return f'You are now **{add[0]}**.' + (
                 f' (Swapped out {", ".join(remove)}.)' if remove else '')

--- a/tests/unit/test_role_picker.py
+++ b/tests/unit/test_role_picker.py
@@ -82,6 +82,59 @@ def test_unknown_value_is_ignored_not_granted():
     assert add == [] and remove == []
 
 
+# -- non-exclusive panels: each menu edits its own set --------------------------
+
+def _regions():
+    """Two menus, like us_states: a member can hold several, and a
+    submission is the complete choice for that one menu."""
+    return rp.Panel.from_dict({
+        'key': 'regions', 'title': 't', 'description': 'd', 'exclusive': False,
+        'groups': [
+            {'placeholder': 'A to M', 'options': [
+                {'label': 'Indiana', 'role': 'Indiana'},
+                {'label': 'Michigan', 'role': 'Michigan'},
+            ]},
+            {'placeholder': 'N to Z', 'options': [
+                {'label': 'Ohio', 'role': 'Ohio'},
+                {'label': 'Pennsylvania', 'role': 'Pennsylvania'},
+            ]},
+        ],
+    })
+
+
+def test_shipped_region_panels_allow_several_roles():
+    panels = rp.load_panels()
+    for key in ('country', 'us_states', 'ca_provinces'):
+        assert panels[key].exclusive is False, key
+
+
+def test_menu_submission_is_the_whole_choice_for_that_menu():
+    # Held Indiana; submitted Michigan only in the A-M menu: Indiana goes,
+    # Michigan comes, Ohio (other menu) is untouched.
+    add, remove = rp.plan_change(_regions(), {'Indiana', 'Ohio'}, ['Michigan'], group=0)
+    assert add == ['Michigan'] and remove == ['Indiana']
+
+
+def test_several_roles_from_one_menu_can_be_held_together():
+    add, remove = rp.plan_change(_regions(), {'Ohio'}, ['Indiana', 'Michigan'], group=0)
+    assert add == ['Indiana', 'Michigan'] and remove == []
+
+
+def test_clearing_one_menu_leaves_the_other_menus_roles():
+    add, remove = rp.plan_change(_regions(), {'Indiana', 'Michigan', 'Ohio'}, [], group=0)
+    assert add == [] and remove == ['Indiana', 'Michigan']
+
+
+def test_non_exclusive_menus_are_multi_select():
+    view = rp.build_view(_regions())
+    assert view.children[0].min_values == 0
+    assert view.children[0].max_values == 2
+
+
+def test_exclusive_menus_stay_single_select():
+    assert rp.build_view(_panel()).children[0].max_values == 1
+
+
 # -- view construction --------------------------------------------------------
 
 def test_view_has_one_persistent_select_per_group():
@@ -91,7 +144,7 @@ def test_view_has_one_persistent_select_per_group():
     assert ids == ['rolepick:us_states:0', 'rolepick:us_states:1', 'rolepick:us_states:2']
     assert view.timeout is None
     select = view.children[0]
-    assert select.min_values == 0 and select.max_values == 1
+    assert select.min_values == 0 and select.max_values == 17
     assert len(select.options) == 17
 
 
@@ -148,6 +201,46 @@ async def test_apply_with_nothing_chosen_clears(cog):
     text = await cog.apply(panel, guild, member, [])
     assert member.removed == ['Michigan'] and member.added == []
     assert 'cleared' in text.lower() or 'removed' in text.lower()
+
+
+async def test_apply_on_a_region_panel_reads_back_the_whole_set(cog):
+    panel = _regions()
+    guild = _guild(['Indiana', 'Michigan', 'Ohio', 'Pennsylvania', 'Penguins'])
+    member = _member([guild.roles[2], guild.roles[4]])      # Ohio + Penguins
+    text = await cog.apply(panel, guild, member, ['Indiana', 'Michigan'], group=0)
+    assert member.added == ['Indiana', 'Michigan'] and member.removed == []
+    assert 'Indiana, Michigan, Ohio' in text                # panel order, all held
+    assert 'Penguins' not in text
+
+
+async def test_apply_clearing_a_region_menu_reads_back_what_is_left(cog):
+    panel = _regions()
+    guild = _guild(['Indiana', 'Michigan', 'Ohio', 'Pennsylvania'])
+    member = _member([guild.roles[0], guild.roles[2]])      # Indiana + Ohio
+    text = await cog.apply(panel, guild, member, [], group=0)
+    assert member.removed == ['Indiana']
+    assert 'Ohio' in text and 'Indiana' not in text.split('Ohio')[-1]
+
+
+async def test_select_callback_passes_its_own_menu_index(cog):
+    panel = _regions()
+    select = rp.PanelSelect(panel, 1)
+    seen = {}
+
+    async def apply(panel, guild, member, chosen, group=None):
+        seen.update(chosen=chosen, group=group)
+        return 'ok'
+    cog.apply = apply
+    sent = []
+
+    async def send_message(text, ephemeral=False):
+        sent.append(text)
+    interaction = types.SimpleNamespace(
+        client=types.SimpleNamespace(get_cog=lambda name: cog),
+        data={'values': ['Ohio']}, guild=None, user=None,
+        response=types.SimpleNamespace(send_message=send_message))
+    await select.callback(interaction)
+    assert seen == {'chosen': ['Ohio'], 'group': 1} and sent == ['ok']
 
 
 async def test_apply_when_role_is_missing_from_guild_says_so(cog):


### PR DESCRIPTION
## Why

The three shipped panels were exclusive: picking Michigan stripped Ohio. The roles exist to route event pings, and a member in Ohio who drives to GrrCON wants both, so one-role-per-panel was the wrong rule for regions. Also, the existing non-exclusive mode had no way to drop a single role: each menu was single-select and an empty submission cleared the whole panel.

## What

- Non-exclusive panels are set editors. Every menu is multi-select (`max_values` = option count); a submission is the member's complete choice **for that menu only**. Unticked roles from that menu are removed, roles from the panel's other menus are untouched.
- Discord does not pre-tick current roles when a menu opens, so the ephemeral reply reads back the full list in panel order: "You are now set for: **Indiana, Michigan, Ohio**."
- `country`, `us_states`, `ca_provinces` flip to `"exclusive": false`, copy rewritten to say tick every region you want pings for, home included.
- Exclusive panels unchanged (one-of choices, e.g. a future pronouns panel if you wanted it that way).
- `docs/features/ROLE_PICKER.md` updated; events spec (#157) will treat every held region role as an alert region, no separate home concept.

## Tests

Nine new, written first and watched fail: per-menu add / remove / clear, other menus untouched, several roles from one menu, multi-select sizing, exclusive stays single-select, callback passes its menu index, readback text. 545 passed, 1 skipped. Ruff clean. No em dashes in added lines.

## Deploy note

The tick limit is baked into a posted message, so any panel already posted needs `/roles post <panel>` again after this lands (and delete the old message). Nothing has been posted in #roles yet, so no cleanup this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
