### PR TITLE
fix: Con Recon phase 1.1, the ten deferred review findings

### DIFF
--- a/docs/features/CON_RECON.md
+++ b/docs/features/CON_RECON.md
@@ -127,7 +127,8 @@ while approving.
 `penguin_events_submissions_total{provenance}`,
 `penguin_events_decisions_total{decision}`,
 `penguin_events_reminders_total{window}`, `penguin_events_post_errors_total`,
-`penguin_events_role_missing_total{role}`, gauge `penguin_events_pending`.
+`penguin_events_role_missing_total{role}`, gauge `penguin_events_pending`
+(submissions awaiting review across every guild, no label).
 
 ## What comes next
 

--- a/docs/features/CON_RECON.md
+++ b/docs/features/CON_RECON.md
@@ -13,7 +13,8 @@ reminds the roles that opted in.
 - **Submit.** `/events submit` takes a title, topic (cyber, ham, foss,
   other), start date, city, a place from the autocomplete list (state,
   province, country, or Online), and optionally an end date, URL, notes
-  and a `national` flag for the DEF CON tier. Duplicates are caught by a
+  and a `national` flag for the DEF CON tier. The title is capped at 120
+  characters, the city at 80 and the notes at 500. Duplicates are caught by a
   fingerprint of the normalised title plus start date. A member can have
   three submissions open at once.
 - **Review.** Every submission posts a card to the review channel

--- a/docs/reference/COMMANDS.md
+++ b/docs/reference/COMMANDS.md
@@ -202,7 +202,7 @@ Reminders tag the picker roles for the event's topic, region and country.
 | `/events approve <id>`, `/events reject <id> <reason>` | | Decide a pending event (the card's buttons do the same). | moderators |
 | `/events edit <id>` | | Open the edit modal for any live event. | moderators |
 | `/events cancel <id> <reason>` | | Cancel an approved event; members who were told about it get one notice. | moderators |
-| `/events status` | | Config, counts, next post and sweep, missing roles. | moderators |
+| `/events status` | | Config, counts, next post and sweep, missing roles, and whether the bot may mention roles and post embeds in the events and review channels. | moderators |
 
 ## Fun and utilities (hybrid, everyone)
 

--- a/docs/reference/COMMANDS.md
+++ b/docs/reference/COMMANDS.md
@@ -196,7 +196,7 @@ Reminders tag the picker roles for the event's topic, region and country.
 | `/events list [topic] [where] [page]` | topic: cyber, ham, foss, other; where: a state, province, country or Online | Approved events in the next year, five per page. | everyone |
 | `/events next` | | The next 30 days. | everyone |
 | `/events search <query>` | title or city | Search approved events. | everyone |
-| `/events submit <title> <topic> <start> <city> <where> [end] [url] [notes] [national]` | dates as YYYY-MM-DD | Propose an event; it lands in the review queue. Up to three open submissions per member. | everyone |
+| `/events submit <title> <topic> <start> <city> <where> [end] [url] [notes] [national]` | dates as YYYY-MM-DD; title up to 120 characters, city up to 80, notes up to 500 | Propose an event; it lands in the review queue. Up to three open submissions per member. | everyone |
 | `/events mine` | | Your submissions and their status. | everyone |
 | `/events pending [repost]` | repost: re-send the review cards | The review queue. | moderators |
 | `/events approve <id>`, `/events reject <id> <reason>` | | Decide a pending event (the card's buttons do the same). | moderators |

--- a/penguin-overlord/cogs/events.py
+++ b/penguin-overlord/cogs/events.py
@@ -489,6 +489,22 @@ class Events(commands.Cog):
         }
 
     SCHEDULE_FIELDS = ('start_date', 'end_date', 'city', 'region_code', 'country_code')
+    CHANGE_KEY_MAX = 128
+
+    @classmethod
+    def _changed_window(cls, event: dict) -> str:
+        """The event_reminders window a change notice claims.
+
+        Scoped to the new dates AND the new place. Keyed on the start date
+        alone, a venue move that kept the date collided with the date move
+        before it on the UNIQUE (event_id, window) index, and members were
+        never told the con had moved across the state. Case and spacing are
+        folded so retyping the same address is not a new claim."""
+        def norm(value) -> str:
+            return ' '.join((value or '').split()).lower()
+
+        place = f"{norm(event.get('city'))}|{norm(event.get('region_code') or event.get('country_code'))}"
+        return f"changed:{event['start_date']}:{place}"[:cls.CHANGE_KEY_MAX]
 
     async def apply_edit(self, interaction: discord.Interaction, event_id: int, changes: dict) -> None:
         # Same two reasons as decide(): the write needs its own
@@ -523,10 +539,7 @@ class Events(commands.Cog):
         await self._reply(interaction, f"#{event_id} {after['title']} updated.")
         schedule_changed = any(before[k] != after[k] for k in self.SCHEDULE_FIELDS)
         if after['status'] == 'approved' and schedule_changed and await self.store.dated_reminder_sent(event_id):
-            # Scoped to the new start date: a second schedule change claims
-            # a different window, so it is not swallowed by the UNIQUE
-            # index on the first 'changed' claim.
-            await self.notify(after, f"changed:{after['start_date']}", changed=True)
+            await self.notify(after, self._changed_window(after), changed=True)
 
     # -- posting ---------------------------------------------------------------
 

--- a/penguin-overlord/cogs/events.py
+++ b/penguin-overlord/cogs/events.py
@@ -788,6 +788,20 @@ class Events(commands.Cog):
                 reposted += 1
         await interaction.followup.send(f'Reposted {reposted} review card(s).', ephemeral=True)
 
+    # The two permissions that silently stop a card or a reminder from
+    # ever appearing; mention_everyone only costs the role pings.
+    POST_PERMS = (('Send Messages', 'send_messages'), ('Embed Links', 'embed_links'))
+
+    @staticmethod
+    def _posting_line(label: str, channel, member, where: str) -> str:
+        if channel is None:
+            return f'{label}: BLOCKED, {where} does not resolve'
+        perms = channel.permissions_for(member)
+        missing = [name for name, attr in Events.POST_PERMS if not getattr(perms, attr)]
+        if not missing:
+            return f'{label}: allowed'
+        return f'{label}: BLOCKED, grant {" and ".join(missing)} in {where}'
+
     @events.command(name='status', description='Con Recon health')
     @app_commands.checks.has_permissions(moderate_members=True)
     async def events_status(self, interaction: discord.Interaction):
@@ -806,6 +820,7 @@ class Events(commands.Cog):
         channel = await self._channel(self.cfg.channel_id)
         can_mention = bool(channel) and channel.permissions_for(interaction.guild.me).mention_everyone
         review = f'<#{self.cfg.review_channel_id}>' if self.cfg.review_channel_id else 'not configured'
+        review_channel = await self._channel(self.cfg.review_channel_id)
         lines = [
             'Con Recon status:',
             f"dry run: {'on' if self.cfg.dry_run else 'off'}; channel <#{self.cfg.channel_id}>; "
@@ -820,7 +835,11 @@ class Events(commands.Cog):
                                                  if missing else ''),
             'role mentions: ' + ('allowed' if can_mention else 'BLOCKED, grant Mention @everyone, @here and All Roles '
                                                               'in the events channel'),
+            self._posting_line('posting', channel, interaction.guild.me, 'the events channel'),
         ]
+        if self.cfg.review_channel_id:
+            lines.append(self._posting_line('review posting', review_channel, interaction.guild.me,
+                                            'the review channel'))
         await self._reply(interaction, '\n'.join(lines))
 
     @events.command(name='approve', description='Approve a pending event by id')

--- a/penguin-overlord/cogs/events.py
+++ b/penguin-overlord/cogs/events.py
@@ -218,7 +218,10 @@ class Events(commands.Cog):
 
     # -- member commands ------------------------------------------------------
 
-    events = app_commands.Group(name='events', description='Con Recon: the community conference calendar')
+    # guild_only: every command below reads or writes rows keyed on
+    # interaction.guild_id, which is None in a DM.
+    events = app_commands.Group(name='events', description='Con Recon: the community conference calendar',
+                                guild_only=True)
 
     @events.command(name='list', description='Upcoming events, soonest first')
     @app_commands.describe(topic='Only this topic', where='Only this state, province or country',

--- a/penguin-overlord/cogs/events.py
+++ b/penguin-overlord/cogs/events.py
@@ -327,7 +327,9 @@ class Events(commands.Cog):
         }
         event_id = await self.store.insert(row, actor_id=user.id, action='submit')
         EVENTS_SUBMISSIONS.labels(provenance='member').inc()
-        EVENTS_PENDING.set(await self.store.pending_count(guild_id))
+        # The gauge has no guild label, so it is the count across every
+        # guild; a per-guild number here made the last writer win.
+        EVENTS_PENDING.set(await self.store.pending_count())
         event = await self.store.get(event_id)
         message_id = await self.post_review_card(event)
         if message_id:
@@ -461,7 +463,7 @@ class Events(commands.Cog):
             await self._reply(interaction, f'Already decided. {self.decided_line(event)}')
             return
         EVENTS_DECISIONS.labels(decision=status).inc()
-        EVENTS_PENDING.set(await self.store.pending_count(event['guild_id']))
+        EVENTS_PENDING.set(await self.store.pending_count())
         logger.info('Event #%d %s by %s%s', event_id, status, interaction.user.id,
                     f': {reason}' if reason else '')
         await self.refresh_card(event)
@@ -716,7 +718,6 @@ class Events(commands.Cog):
         if released_claims:
             logger.info('Events sweep: released %d orphaned reminder claim(s)', released_claims)
         retired = await self.store.retire_ended(today.isoformat())
-        guild_ids = {row['guild_id'] for row in retired}
         rolled = 0
         for row in retired:
             if row['recurrence'] != 'annual' or row['status'] != 'approved':
@@ -741,11 +742,9 @@ class Events(commands.Cog):
             EVENTS_DECISIONS.labels(decision='expired').inc()
             expired_row = await self.store.get(event_id)
             if expired_row:
-                guild_ids.add(expired_row['guild_id'])
                 await self.refresh_card(expired_row)
         purged = await self.store.purge_rejected((now - timedelta(days=REJECTED_KEEP_DAYS)).isoformat())
-        for guild_id in guild_ids:
-            EVENTS_PENDING.set(await self.store.pending_count(guild_id))
+        EVENTS_PENDING.set(await self.store.pending_count())
         result = {'retired': len(retired), 'rolled': rolled, 'expired': len(expired_ids), 'purged': purged,
                   'released_claims': released_claims}
         logger.info('Events sweep for %s: %s', today, result)

--- a/penguin-overlord/utils/events_logic.py
+++ b/penguin-overlord/utils/events_logic.py
@@ -31,6 +31,9 @@ PROVENANCES = ('member', 'calendar', 'ai', 'rollover')
 
 MAX_NOTES = 500
 MAX_TITLE = 120
+# The edit modal's location line is capped at 80 by Discord, so a longer
+# city could never be edited back once it was submitted.
+MAX_CITY = 80
 MAX_YEARS_AHEAD = 2
 
 _PUNCT = re.compile(r'[^a-z0-9 ]+')
@@ -131,6 +134,8 @@ def validate_submission(*, title: str, topic: str, start: str, end: Optional[str
     city = (city or '').strip()
     if not city:
         return None, 'A city is required (use Online for virtual events).'
+    if len(city) > MAX_CITY:
+        return None, f'The city is over {MAX_CITY} characters.'
     url = (url or '').strip() or None
     if url and not url.lower().startswith(('http://', 'https://')):
         return None, 'The url must start with http:// or https://.'

--- a/penguin-overlord/utils/events_logic.py
+++ b/penguin-overlord/utils/events_logic.py
@@ -36,7 +36,9 @@ MAX_TITLE = 120
 MAX_CITY = 80
 MAX_YEARS_AHEAD = 2
 
-_PUNCT = re.compile(r'[^a-z0-9 ]+')
+# Everything that is not a unicode word character, plus the underscore
+# \w includes. Latin letters, Cyrillic, kana and kanji all survive.
+_PUNCT = re.compile(r'[\W_]+', re.UNICODE)
 _NUMBER_WORD = re.compile(r'\b\d+\b')          # a year or an edition number on its own
 _SPACES = re.compile(r'\s+')
 
@@ -44,11 +46,16 @@ _SPACES = re.compile(r'\s+')
 # -- fingerprint ---------------------------------------------------------------
 
 def normalize_title(title: str) -> str:
-    """Lowercase ASCII, punctuation gone, standalone numbers gone (years and
-    edition numbers), whitespace collapsed. 'DEF CON 34' and 'DEF CON 35'
-    collide on purpose; the start year in fingerprint() separates them."""
-    text = unicodedata.normalize('NFKD', title).encode('ascii', 'ignore').decode()
-    text = _PUNCT.sub(' ', text.lower())
+    """NFKC, casefolded, punctuation gone, standalone numbers gone (years
+    and edition numbers), whitespace collapsed. 'DEF CON 34' and 'DEF CON
+    35' collide on purpose; the start year in fingerprint() separates them.
+
+    Word characters are kept in any script. An earlier version folded to
+    ASCII first, which left every Japanese or Cyrillic title as the empty
+    string, so all of them collided on ':YYYY' and only the first one could
+    ever be stored. An ASCII title normalises to exactly what it did then."""
+    text = unicodedata.normalize('NFKC', title or '').casefold()
+    text = _PUNCT.sub(' ', text)
     text = _NUMBER_WORD.sub(' ', text)
     return _SPACES.sub(' ', text).strip()
 

--- a/penguin-overlord/utils/events_store.py
+++ b/penguin-overlord/utils/events_store.py
@@ -358,8 +358,16 @@ class EventsStore:
 
     async def purge_rejected(self, cutoff_iso: str) -> int:
         """Delete rejected rows decided before the cutoff (180 days in the
-        sweep). Audit rows stay."""
+        sweep), and their reminder rows, in one transaction. Audit rows stay.
+
+        PRAGMA foreign_keys is off, so nothing cascades: an orphaned
+        event_reminders row would keep (event_id, window) claimed, and a
+        later event that reused the rowid would read as already reminded."""
         async with self.db.lock:
+            await self._conn.execute(
+                """DELETE FROM event_reminders WHERE event_id IN (
+                       SELECT id FROM events WHERE status = 'rejected' AND decided_at < ?)""",
+                (cutoff_iso,))
             cursor = await self._conn.execute(
                 "DELETE FROM events WHERE status = 'rejected' AND decided_at < ?", (cutoff_iso,))
             await self._conn.commit()

--- a/penguin-overlord/utils/events_store.py
+++ b/penguin-overlord/utils/events_store.py
@@ -172,9 +172,15 @@ class EventsStore:
                ORDER BY id ASC LIMIT ?""", (guild_id, limit))
         return [dict(r) for r in await cursor.fetchall()]
 
-    async def pending_count(self, guild_id: int) -> int:
-        cursor = await self._conn.execute(
-            "SELECT COUNT(*) FROM events WHERE guild_id = ? AND status = 'pending'", (guild_id,))
+    async def pending_count(self, guild_id: int | None = None) -> int:
+        """Rows awaiting review, in one guild or (guild_id=None) in all of
+        them. The penguin_events_pending gauge carries no label, so it is
+        the global count that belongs in it."""
+        if guild_id is None:
+            cursor = await self._conn.execute("SELECT COUNT(*) FROM events WHERE status = 'pending'")
+        else:
+            cursor = await self._conn.execute(
+                "SELECT COUNT(*) FROM events WHERE guild_id = ? AND status = 'pending'", (guild_id,))
         return (await cursor.fetchone())[0]
 
     async def counts(self, guild_id: int) -> dict:

--- a/penguin-overlord/utils/events_store.py
+++ b/penguin-overlord/utils/events_store.py
@@ -37,6 +37,17 @@ def _dump(row) -> str | None:
     return None if row is None else json.dumps(dict(row), default=str, sort_keys=True)
 
 
+def _like_escape(text: str) -> str:
+    """Make a member's search text literal for LIKE ... ESCAPE '\\'.
+
+    Unescaped, a query of '100%' matched every title and '_' matched any
+    single character. The backslash goes first so it does not double the
+    escapes this function itself adds."""
+    for char in ('\\', '%', '_'):
+        text = text.replace(char, '\\' + char)
+    return text
+
+
 class EventsStore:
     def __init__(self, db: ModerationDatabase):
         self.db = db
@@ -138,12 +149,12 @@ class EventsStore:
         return [dict(r) for r in await cursor.fetchall()]
 
     async def search(self, guild_id: int, query: str, *, today: str, limit: int = 10) -> list[dict]:
-        like = f'%{query.strip().lower()}%'
+        like = f'%{_like_escape(query.strip().lower())}%'
         cursor = await self._conn.execute(
-            """SELECT * FROM events
-               WHERE guild_id = ? AND status IN ('approved', 'cancelled') AND start_date >= ?
-                 AND (lower(title) LIKE ? OR lower(coalesce(city, '')) LIKE ?)
-               ORDER BY start_date, id LIMIT ?""",
+            r"""SELECT * FROM events
+                WHERE guild_id = ? AND status IN ('approved', 'cancelled') AND start_date >= ?
+                  AND (lower(title) LIKE ? ESCAPE '\' OR lower(coalesce(city, '')) LIKE ? ESCAPE '\')
+                ORDER BY start_date, id LIMIT ?""",
             (guild_id, today, like, like, limit))
         return [dict(r) for r in await cursor.fetchall()]
 

--- a/penguin-overlord/utils/events_store.py
+++ b/penguin-overlord/utils/events_store.py
@@ -292,9 +292,10 @@ class EventsStore:
         change or cancellation is worth a notice: nobody saw an event that
         was never announced. An explicit allowlist rather than excluding
         'changed'/'cancelled' by name: a change notice for a second edit is
-        scoped to its own window (`changed:<start_date>`, so a repeat edit
-        is not swallowed by the UNIQUE index on the first claim), and that
-        scoped window must not be mistaken for a dated reminder either."""
+        scoped to its own window (`changed:<start_date>:<city>|<region>`, so
+        a repeat edit, including a venue move that keeps the date, is not
+        swallowed by the UNIQUE index on the first claim), and that scoped
+        window must not be mistaken for a dated reminder either."""
         cursor = await self._conn.execute(
             """SELECT 1 FROM event_reminders
                WHERE event_id = ? AND posted_at IS NOT NULL AND window IN ('30', '7', '1')

--- a/tests/unit/test_env_example_events.py
+++ b/tests/unit/test_env_example_events.py
@@ -1,0 +1,81 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""`.env.example` must document exactly the `EVENTS_*` variables the config
+loader reads: no missing line for an operator to discover the hard way, and
+no leftover key the loader stopped reading.
+
+The EVENTS_ block was written by hand and never checked against
+`_load_events`. This test only ever reports variable NAMES; it never reads,
+compares or prints a value from `.env.example`, which on a developer's
+machine may sit next to a real `.env`.
+"""
+
+import re
+from pathlib import Path
+from typing import Mapping
+
+from utils import config
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENV_EXAMPLE = REPO_ROOT / '.env.example'
+
+# KEY= at the start of a line, with or without an `export` prefix. The
+# value is deliberately not captured.
+_KEY_LINE = re.compile(r'^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=')
+
+
+class _Recorder(Mapping):
+    """An empty environment that remembers which names were asked for, so
+    the expected set comes from the loader itself rather than a list here
+    that could drift away from it."""
+
+    def __init__(self):
+        self.names: set[str] = set()
+
+    def __getitem__(self, key):
+        self.names.add(key)
+        raise KeyError(key)
+
+    def __iter__(self):
+        return iter(())
+
+    def __len__(self):
+        return 0
+
+
+def _names_the_loader_reads() -> set[str]:
+    recorder = _Recorder()
+    config._load_events(config._Reader(recorder, None))
+    return {name for name in recorder.names if name.startswith('EVENTS_')}
+
+
+def _names_in_env_example() -> set[str]:
+    keys = set()
+    for line in ENV_EXAMPLE.read_text(encoding='utf-8').splitlines():
+        if line.lstrip().startswith('#'):
+            continue
+        match = _KEY_LINE.match(line)
+        if match:
+            keys.add(match.group(1))
+    return {name for name in keys if name.startswith('EVENTS_')}
+
+
+def test_env_example_documents_every_events_variable():
+    missing = sorted(_names_the_loader_reads() - _names_in_env_example())
+    assert not missing, f'.env.example is missing: {", ".join(missing)}'
+
+
+def test_env_example_has_no_events_variable_the_loader_ignores():
+    unknown = sorted(_names_in_env_example() - _names_the_loader_reads())
+    assert not unknown, f'.env.example documents keys _load_events never reads: {", ".join(unknown)}'
+
+
+def test_the_loader_reads_the_documented_events_surface():
+    # A guard on the guard: if _load_events stopped reading anything, or
+    # the parser stopped finding keys, the two tests above would pass
+    # vacuously on two empty sets.
+    read = _names_the_loader_reads()
+    assert 'EVENTS_ENABLED' in read and len(read) > 5
+    assert len(_names_in_env_example()) > 5

--- a/tests/unit/test_events_cog.py
+++ b/tests/unit/test_events_cog.py
@@ -1106,3 +1106,12 @@ async def test_dry_run_counts_missing_roles_so_the_rollout_can_watch_them(cog, m
     eid = await cog.store.insert(event(), actor_id=0, action='import')
     assert await cog.notify(await cog.store.get(eid), '30') is True
     assert counter.counted == [{'role': 'Michigan'}]
+
+
+# -- phase 1.1: guild-only ------------------------------------------------------
+
+def test_events_group_is_guild_only():
+    # Every /events command reads or writes guild-scoped rows and calls
+    # interaction.guild_id; in a DM that is None and the command would
+    # quietly operate on a guild that does not exist.
+    assert Events.events.guild_only is True

--- a/tests/unit/test_events_cog.py
+++ b/tests/unit/test_events_cog.py
@@ -1115,3 +1115,47 @@ def test_events_group_is_guild_only():
     # interaction.guild_id; in a DM that is None and the command would
     # quietly operate on a guild that does not exist.
     assert Events.events.guild_only is True
+
+
+# -- phase 1.1: the disabled cog stays quiet ------------------------------------
+
+DISABLED_CALLS = (
+    ('events_list', (), {}),
+    ('events_next', (), {}),
+    ('events_search', ('grrcon',), {}),
+    ('events_submit', ('GrrCON', 'cyber', '2026-09-24', 'Grand Rapids', 'US-MI'), {}),
+    ('events_mine', (), {}),
+    ('events_pending', (), {}),
+    ('events_status', (), {}),
+    ('events_approve', (), {'event_id': 1}),
+    ('events_reject', (), {'event_id': 1, 'reason': 'no'}),
+    ('events_edit', (), {'event_id': 1}),
+    ('events_cancel', (), {'event_id': 1, 'reason': 'no'}),
+)
+
+
+@pytest.fixture
+async def off_cog(tmp_data_dir, monkeypatch):
+    """The cog as bot.py loads it with EVENTS_ENABLED unset: registered,
+    no store, no loops. Registration is left alone on purpose; every other
+    feature cog in cogs/ loads unconditionally and gates at runtime."""
+    monkeypatch.delenv('EVENTS_ENABLED', raising=False)
+    c = Events(types.SimpleNamespace(config=None))
+    await c.cog_load()
+    assert c.store is None
+    return c
+
+
+@pytest.mark.parametrize('name, args, kwargs', DISABLED_CALLS)
+async def test_disabled_cog_refuses_every_command_ephemerally(off_cog, name, args, kwargs):
+    i = interaction(mod=True)
+    await getattr(off_cog, name).callback(off_cog, i, *args, **kwargs)
+    assert [s.content for s in i.response.sent] == [DISABLED_TEXT]
+    assert all(s.ephemeral for s in i.response.sent)
+
+
+async def test_disabled_cog_refuses_a_review_button_ephemerally(off_cog):
+    button = EventButton(1, 'approve')
+    i = interaction(mod=True, client=types.SimpleNamespace(get_cog=lambda name: off_cog))
+    await button.callback(i)
+    assert i.response.sent[0].content == DISABLED_TEXT and i.response.sent[0].ephemeral

--- a/tests/unit/test_events_cog.py
+++ b/tests/unit/test_events_cog.py
@@ -1236,3 +1236,41 @@ async def test_status_says_nothing_about_a_review_channel_it_does_not_have(cog):
     i = interaction(user_id=7, mod=True, guild=guild)
     await cog.events_status.callback(cog, i)
     assert 'review posting' not in i.response.sent[-1].content
+
+
+# -- phase 1.1: the pending gauge is global -------------------------------------
+
+class FakeGauge:
+    def __init__(self):
+        self.value = None
+
+    def set(self, value):
+        self.value = value
+
+
+async def test_pending_gauge_counts_every_guild(cog, monkeypatch):
+    # penguin_events_pending carries no label, so setting it from one
+    # guild's count made the last write win and the number bounced.
+    gauge = FakeGauge()
+    for target in (cog.events_submit.callback, cog.decide, cog.run_sweep):
+        monkeypatch.setitem(getattr(target, '__globals__', None) or target.__func__.__globals__,
+                            'EVENTS_PENDING', gauge)
+    wire(cog)
+    await cog.store.insert(event(title='Other', fingerprint='other:2026', guild_id=99,
+                                 status='pending', submitted_by=7), actor_id=7, action='submit')
+    await submit(cog)                                            # one pending row in GUILD
+    assert await cog.store.pending_count(GUILD) == 1
+    assert gauge.value == 2                                      # both guilds
+    assert await cog.store.pending_count() == 2                  # no guild: every guild
+
+
+async def test_sweep_sets_the_pending_gauge_from_every_guild(cog, monkeypatch):
+    gauge = FakeGauge()
+    monkeypatch.setitem(cog.run_sweep.__globals__, 'EVENTS_PENDING', gauge)
+    wire(cog)
+    await cog.store.insert(event(title='Other', fingerprint='other:2026', guild_id=99,
+                                 status='pending', submitted_by=7), actor_id=7, action='submit')
+    await cog.store.insert(event(start_date='2026-05-30', end_date='2026-05-30'),
+                           actor_id=0, action='import')
+    await cog.run_sweep(today=dt.date(2026, 9, 3))
+    assert gauge.value == 2                                      # the rollover plus guild 99's row

--- a/tests/unit/test_events_cog.py
+++ b/tests/unit/test_events_cog.py
@@ -1159,3 +1159,45 @@ async def test_disabled_cog_refuses_a_review_button_ephemerally(off_cog):
     i = interaction(mod=True, client=types.SimpleNamespace(get_cog=lambda name: off_cog))
     await button.callback(i)
     assert i.response.sent[0].content == DISABLED_TEXT and i.response.sent[0].ephemeral
+
+
+# -- phase 1.1: a venue move is a change worth announcing -----------------------
+
+async def test_venue_only_edit_of_an_announced_event_posts_a_change_notice(cog):
+    # The dedupe window used to be 'changed:<start_date>' alone, so moving
+    # the venue without moving the date collided with the date change that
+    # came before it and the notice was silently dropped.
+    guild, channels = wire(cog)
+    eid = await cog.store.insert(event(), actor_id=0, action='import')
+    await cog.notify(await cog.store.get(eid), '30')
+    i = interaction(user_id=7, mod=True)
+    await cog.apply_edit(i, eid, {'start_date': '2026-09-25', 'end_date': '2026-09-26'})
+    i = interaction(user_id=7, mod=True)
+    await cog.apply_edit(i, eid, {'city': 'Detroit'})                  # same date, new venue
+    posts = channels[5000].sent
+    assert len(posts) == 3                                 # reminder, date change, venue change
+    assert posts[2].embed.title.startswith('Updated: GrrCON')
+    i = interaction(user_id=7, mod=True)
+    await cog.apply_edit(i, eid, {'region_code': 'US-OH', 'country_code': 'US'})
+    assert len(channels[5000].sent) == 4                   # a region move is a change too
+
+
+async def test_notes_or_url_only_edits_still_post_no_change_notice(cog):
+    guild, channels = wire(cog)
+    eid = await cog.store.insert(event(), actor_id=0, action='import')
+    await cog.notify(await cog.store.get(eid), '30')
+    i = interaction(user_id=7, mod=True)
+    await cog.apply_edit(i, eid, {'notes': 'parking is free'})
+    i = interaction(user_id=7, mod=True)
+    await cog.apply_edit(i, eid, {'url': 'https://grrcon.example'})
+    assert len(channels[5000].sent) == 1                   # the reminder, nothing else
+
+
+async def test_change_window_key_folds_case_and_whitespace(cog):
+    # Re-typing the same city with different spacing is not a change, so
+    # it must land on the window the first notice already claimed.
+    a = cog._changed_window(event(start_date='2026-09-24', city='Grand Rapids', region_code='US-MI'))
+    b = cog._changed_window(event(start_date='2026-09-24', city='  grand   rapids ', region_code='us-mi'))
+    assert a == b == 'changed:2026-09-24:grand rapids|us-mi'
+    assert cog._changed_window(event(start_date='2026-09-24', city='Detroit')) != a
+    assert len(cog._changed_window(event(city='x' * 500))) <= 128

--- a/tests/unit/test_events_cog.py
+++ b/tests/unit/test_events_cog.py
@@ -84,18 +84,21 @@ class FakeMessage:
 
 
 class FakeChannel:
-    def __init__(self, cid, *, fail=False, guild_id=GUILD):
+    def __init__(self, cid, *, fail=False, guild_id=GUILD, perms=None):
         self.id = cid
         self.sent = []
         self.messages = {}
         self.fail = fail
         self._next = 1000
+        self.perms = perms
         # run_poster and run_digest scope their rows to the channel's own
         # guild, so a real channel object always carries one.
         self.guild = types.SimpleNamespace(id=guild_id)
 
     def permissions_for(self, member):
-        return discord.Permissions(mention_everyone=not self.fail)
+        if self.perms is not None:
+            return self.perms
+        return discord.Permissions(mention_everyone=not self.fail, send_messages=True, embed_links=True)
 
     async def send(self, content=None, *, embed=None, view=None, allowed_mentions=None):
         if self.fail:
@@ -1201,3 +1204,35 @@ async def test_change_window_key_folds_case_and_whitespace(cog):
     assert a == b == 'changed:2026-09-24:grand rapids|us-mi'
     assert cog._changed_window(event(start_date='2026-09-24', city='Detroit')) != a
     assert len(cog._changed_window(event(city='x' * 500))) <= 128
+
+
+# -- phase 1.1: status checks the permissions that actually stop a post --------
+
+async def test_status_reports_send_and_embed_permissions(cog):
+    guild, channels = wire(cog)
+    i = interaction(user_id=7, mod=True, guild=guild)
+    await cog.events_status.callback(cog, i)
+    text = i.response.sent[-1].content
+    assert 'posting: allowed' in text and 'review posting: allowed' in text
+
+
+async def test_status_names_the_missing_posting_permissions(cog):
+    # mention_everyone alone was checked, so a bot that could not speak in
+    # the events channel at all still reported a clean bill of health.
+    guild, channels = wire(cog, channels={
+        5000: FakeChannel(5000, perms=discord.Permissions(mention_everyone=True)),
+        6000: FakeChannel(6000, perms=discord.Permissions(send_messages=True)),
+    })
+    i = interaction(user_id=7, mod=True, guild=guild)
+    await cog.events_status.callback(cog, i)
+    text = i.response.sent[-1].content
+    assert 'posting: BLOCKED, grant Send Messages and Embed Links in the events channel' in text
+    assert 'review posting: BLOCKED, grant Embed Links in the review channel' in text
+
+
+async def test_status_says_nothing_about_a_review_channel_it_does_not_have(cog):
+    guild, channels = wire(cog)
+    cog.cfg = cog.cfg.__class__(**{**cog.cfg.__dict__, 'review_channel_id': None})
+    i = interaction(user_id=7, mod=True, guild=guild)
+    await cog.events_status.callback(cog, i)
+    assert 'review posting' not in i.response.sent[-1].content

--- a/tests/unit/test_events_logic.py
+++ b/tests/unit/test_events_logic.py
@@ -120,11 +120,19 @@ def test_missing_end_copies_start():
     (dict(topic='crypto'), 'topic'),
     (dict(title='   '), 'title'),
     (dict(city=''), 'city'),
+    (dict(city='x' * 81), '80'),
     (dict(notes='x' * 501), '500'),
 ])
 def test_invalid_submissions_name_the_problem(over, fragment):
     clean, problem = _submit(**over)
     assert clean is None and fragment in problem
+
+
+def test_city_at_the_limit_is_accepted_and_one_over_is_not():
+    clean, problem = _submit(city='x' * el.MAX_CITY)
+    assert problem is None and clean['city'] == 'x' * el.MAX_CITY
+    clean, problem = _submit(city='x' * (el.MAX_CITY + 1))
+    assert clean is None and problem == f'The city is over {el.MAX_CITY} characters.'
 
 
 def test_parse_dates_field_single_and_range():

--- a/tests/unit/test_events_logic.py
+++ b/tests/unit/test_events_logic.py
@@ -21,10 +21,33 @@ from utils import events_logic as el
     ('  GrrCON!!  ', 'grrcon'),
     ('BSides312 (Chicago)', 'bsides312 chicago'),
     ('Dayton Hamvention 2026', 'dayton hamvention'),
-    ('Café Con', 'cafe con'),
+    # The accent survives now: folding to ASCII first is what erased
+    # non-Latin titles entirely, so nothing is transliterated any more.
+    ('Café Con', 'café con'),
+    ('Код Безопасности 2026', 'код безопасности'),
+    ('セキュリティキャンプ 2026', 'セキュリティキャンプ'),
 ])
 def test_normalize_title_strips_case_punctuation_years_and_editions(title, expected):
     assert el.normalize_title(title) == expected
+
+
+def test_non_latin_titles_keep_their_own_fingerprints():
+    # The normaliser used to strip to [a-z0-9], so every Japanese or
+    # Cyrillic title became '' and collided on ':YYYY'.
+    ru = el.fingerprint('Код Безопасности 2026', date(2026, 11, 24))
+    jp = el.fingerprint('セキュリティキャンプ 2026', date(2026, 8, 10))
+    assert ru == 'код безопасности:2026'
+    assert jp == 'セキュリティキャンプ:2026'
+    assert ru != jp and not ru.startswith(':') and not jp.startswith(':')
+
+
+def test_ascii_fingerprints_are_exactly_what_they_were():
+    # Pinned before the normaliser learned unicode: rows already in the
+    # database carry these strings, and the UNIQUE (guild_id, fingerprint)
+    # index is what stops one event getting two reminder sets.
+    assert el.fingerprint('GrrCON', date(2026, 9, 24)) == 'grrcon:2026'
+    assert el.fingerprint('DEF CON 34', date(2026, 8, 6)) == 'def con:2026'
+    assert el.fingerprint('BSides312 (Chicago)', date(2027, 3, 12)) == 'bsides312 chicago:2027'
 
 
 def test_fingerprint_carries_the_start_year():

--- a/tests/unit/test_events_store.py
+++ b/tests/unit/test_events_store.py
@@ -298,3 +298,20 @@ async def test_expire_pending_and_purge_rejected(store):
     assert await store.purge_rejected('2999-01-01T00:00:00+00:00') == 1
     assert await store.get(ids['pend']) is None
     assert len(await store.audit_rows(ids['pend'])) == 2      # the trail outlives the row
+
+
+async def test_purge_rejected_takes_the_reminder_rows_with_it(store):
+    # PRAGMA foreign_keys is off, so a reminder row survived its event and
+    # kept the id claimed: a later event reusing that rowid would look as
+    # though its reminders had already gone out.
+    ids = await _seed(store)
+    kept = await store.insert(event(fingerprint='kept:2026', status='approved'),
+                              actor_id=0, action='import')
+    await store.claim_reminder(kept, '30', 5000)
+    await store.expire_pending('2999-01-01T00:00:00+00:00')
+    doomed = ids['pend']
+    await store.claim_reminder(doomed, '30', 5000)
+    await store.claim_reminder(doomed, '7', 5000)
+    assert await store.purge_rejected('2999-01-01T00:00:00+00:00') == 1
+    cursor = await store.db.conn.execute('SELECT event_id FROM event_reminders ORDER BY id')
+    assert [r['event_id'] for r in await cursor.fetchall()] == [kept]

--- a/tests/unit/test_events_store.py
+++ b/tests/unit/test_events_store.py
@@ -124,6 +124,18 @@ async def test_search_matches_title_or_city_case_insensitively(store):
     assert await store.search(1, 'queen', today='2026-09-03') == []
 
 
+async def test_search_treats_like_wildcards_as_literal_text(store):
+    # Unescaped, '%' and '_' in a member's query are LIKE wildcards, so
+    # '100%' matched every title and '_' matched any single character.
+    for title in ('1000 attendees', '100% Free Con', 'AB Con', 'A_B Con'):
+        await store.insert(event(title=title, fingerprint=f'{title.lower()}:2026',
+                                 start_date='2026-10-01', end_date='2026-10-01',
+                                 status='approved'), actor_id=0, action='import')
+    assert [r['title'] for r in await store.search(1, '100%', today='2026-09-03')] == ['100% Free Con']
+    assert [r['title'] for r in await store.search(1, 'a_b', today='2026-09-03')] == ['A_B Con']
+    assert await store.search(1, r'100\%', today='2026-09-03') == []
+
+
 async def test_mine_and_open_submission_count(store):
     ids = await _seed(store)
     assert await store.count_open_submissions(1, 42) == 1


### PR DESCRIPTION
## Summary

Phase 1.1 of Con Recon: the ten small findings the whole-branch review of #161 parked. One branch, one commit per item, each driven by a test written first. No behaviour outside the events feature changes.

| # | Finding | Ruling applied | Commit |
| --- | --- | --- | --- |
| 1 | `/events` usable in DMs | `guild_only=True` on the group | 2adc9b6 |
| 2 | Cog registers `/events` when `EVENTS_ENABLED=false` | Every feature cog loads and answers (unanimous convention); registration left alone, the ephemeral refusal is now pinned by tests on all eleven commands and the review button | 6f81cea |
| 3 | `city` unbounded on `/events submit` | Capped at 80 (the edit modal's own limit), same phrasing as the title cap | 470c69f |
| 4 | Venue-only edit of an announced event never re-notified | Change window key is now `changed:<start>:<city>\|<region>` (lowercased, whitespace collapsed, capped at 128); notes-only and url-only edits still stay quiet | 203c194 |
| 5 | `purge_rejected` left `event_reminders` rows behind | Deleted in the same transaction | 585b71f |
| 6 | `/events status` only checked `mention_everyone` | Adds `posting:` (Send Messages, Embed Links) for the events channel and `review posting:` for the review channel | 9d509b3 |
| 7 | Non-Latin titles all fingerprinted to `:YYYY` | NFKC + casefold + unicode word characters; three ASCII fingerprints pinned before the change and unchanged after | e243428 |
| 8 | `/events search` did not escape LIKE wildcards | `%`, `_` and `\` escaped with `ESCAPE '\'` | 4bcc0c7 |
| 9 | `EVENTS_PENDING` gauge set from a per-guild count | Global pending count, no label; sweep no longer loops per guild | 5a28f3b |
| 10 | `.env.example` EVENTS_ block never verified | New test derives the loader's variable names by recording what `_load_events` reads and compares both directions; the file already matched (nothing appended) | 8a11ba0 |

## Worth a look while reviewing

- Item 7 has one deliberate side effect: `Café Con` and `Cafe Con` no longer collide as duplicates (the ASCII fold that erased non-Latin titles was also what transliterated accents). No stored fingerprint changes.
- Item 2 left one gap alone on purpose: when the cog is disabled, `EventButton` is never registered, so a review card left over from an enabled period gives Discord's generic "interaction failed" instead of the one-line refusal. Moving the registration is a behaviour change the ruling did not cover.
- The `event_reminders.window` column comment in `utils/database.py` has been stale since phase 1 (real windows include `changed:...` and `digest:...`). Outside this branch's files, left as is.

## Merge order

Merge this before `feat/typed-config-cogs` and `feat/con-recon-hackertracker`; both touch `cogs/events.py` and the events tests around these lines and will rebase onto this.

## Test plan

- [x] `python -m pytest tests/unit -q` exit 0 (819 tests, 1 pre-existing skip)
- [x] `ruff check penguin-overlord tests scripts` clean
- [x] No em dash in the diff or any commit message; `.env.example` untouched
- [ ] After deploy: `/events status` shows the two new posting lines; `/events search 100%` returns nothing spurious

🤖 Generated with [Claude Code](https://claude.com/claude-code)
