### PR TITLE
refactor(events): the events cog reads bot.config through section_config

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -56,9 +56,8 @@ on a schedule (Gemini free tier) and stored, never called per request.
    startup, logs the effective config redacted, and fails on unknown keys.
    Kills the "set it in .env, forgot to recreate the container" class of
    bug, and is a prerequisite for ConfigMaps and Secrets on Kubernetes.
-   (done except the events cog 2026-09-05; every cog, the `ai/` package and
-   the utils read `utils/config.py`, `cogs/events.py` still calls
-   `load_events_config()` instead of `section_config(bot, 'events')`.)
+   (done 2026-09-06; every cog including events, the `ai/` package and the
+   utils read `utils/config.py`.)
 5. **Deploy script.** Verify the image revision matches the merge SHA,
    recreate, tail for the "active" log lines, roll back on a failed
    healthcheck. Replaces a hand-typed 400-character `docker run`.

--- a/docs/reference/CONFIGURATION.md
+++ b/docs/reference/CONFIGURATION.md
@@ -195,7 +195,5 @@ Everything reads the typed config: `bot.py`, the five runners,
 package. `utils/secrets.py` keeps its own reads: it is the secrets layer
 the loaders depend on.
 
-One follow-up remains: `cogs/events.py` still calls `load_events_config()`
-directly instead of `section_config(bot, 'events')`. It is the same typed
-`EventsConfig` either way, so the cog reads no environment of its own; it
-just does not prefer the already-loaded `bot.config`.
+The events cog is no exception: `Events.__init__` reads
+`section_config(bot, 'events')` like the rest.

--- a/penguin-overlord/cogs/events.py
+++ b/penguin-overlord/cogs/events.py
@@ -26,7 +26,7 @@ from discord.ext import commands, tasks
 from utils import database
 from utils import events_cards as cards
 from utils import hackertracker
-from utils.config import load_events_config
+from utils.config import section_config
 from utils.database import get_database
 from utils.events_logic import (LOCATION_UNSET, TOPIC_LABELS, TOPIC_ROLES, days_until, due_window, fingerprint,
                                 load_regions, local_today, location_field, next_annual_dates, parse_dates_field,
@@ -143,8 +143,7 @@ class Events(commands.Cog):
 
     def __init__(self, bot):
         self.bot = bot
-        config = getattr(bot, 'config', None)
-        self.cfg = config.events if config is not None else load_events_config()
+        self.cfg = section_config(bot, 'events')
         self.store: Optional[EventsStore] = None
         self.regions = load_regions()
         self._warned_roles: dict = {}    # role name -> local date it was last warned about

--- a/tests/unit/test_events_cog.py
+++ b/tests/unit/test_events_cog.py
@@ -1587,3 +1587,17 @@ async def test_status_mentions_discovery(cog):
     mod = interaction(mod=True)
     await cog.events_status.callback(cog, mod)
     assert 'discovery: off' in mod.response.sent[-1].content     # sent[0] is the defer
+
+
+# -- typed config -----------------------------------------------------------------
+
+def test_events_reads_the_bots_typed_config_first(tmp_data_dir, monkeypatch):
+    from tests.conftest import bot_with_config
+    monkeypatch.setenv('EVENTS_DRY_RUN', 'true')                    # env says dry run
+    typed = Events(bot_with_config(EVENTS_ENABLED='true', EVENTS_DRY_RUN='false',
+                                   EVENTS_CHANNEL_ID='100000000000000001'))
+    assert typed.cfg.dry_run is False and typed.cfg.channel_id == 100000000000000001
+    # A bot without a real Config (tests, tooling, a MagicMock) falls back to
+    # a lenient environment load instead of trusting whatever it answers.
+    from unittest.mock import MagicMock
+    assert Events(MagicMock()).cfg.dry_run is True


### PR DESCRIPTION
The one-line follow-up #163 left open: `cogs/events.py` now reads `section_config(self.bot, 'events')` like every other cog, instead of `config.events if config is not None else load_events_config()`.

Why it matters beyond tidiness: the old form trusted any `bot.config` attribute, so a `MagicMock` bot handed the cog a mock timezone and the constructor blew up in `ZoneInfo`. `section_config` falls back to the lenient loader unless `bot.config` is a real `Config`.

- Test: `test_events_reads_the_bots_typed_config_first` (real `Config` wins over env; `MagicMock` falls back). Written first, failed on the `ZoneInfo` error, passes after.
- Docs: ROADMAP item 4 and CONFIGURATION.md no longer list the events cog as the exception.
- Full unit suite exit 0, ruff clean. No behaviour change for the deployed bot: `bot.py` builds a real `Config`, which both forms preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
